### PR TITLE
feat: add fuzz testing, mutation testing, and Makefile interface references

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ go-development-skill/
     ├── resilience.md                     # Retry, shutdown, recovery
     ├── docker.md                         # Docker client patterns
     ├── ldap.md                           # LDAP/Active Directory integration
-    └── testing.md                        # Test strategies and patterns
+    ├── testing.md                        # Test strategies and patterns
+    ├── linting.md                        # golangci-lint v2 configuration
+    ├── api-design.md                     # Bitmask options, functional options
+    ├── fuzz-testing.md                   # Go fuzzing patterns, security seeds
+    ├── mutation-testing.md               # Gremlins test quality measurement
+    └── makefile.md                       # Standard Makefile interface
 ```
 
 ## Expertise Areas
@@ -173,6 +178,16 @@ test:
 2. **Connection Reuse**: Single client instance, connection pooling
 3. **Lazy Initialization**: Initialize resources on first use
 4. **Context Deadlines**: Prevent runaway operations
+
+## Related Skills
+
+This skill focuses on Go code patterns and quality. For complete project setup:
+
+| Skill | Purpose |
+|-------|---------|
+| `github-project` | Repository setup, branch protection, auto-merge workflows |
+| `enterprise-readiness` | OpenSSF Scorecard, SLSA provenance, signed releases |
+| `security-audit` | OWASP Top 10, CVE analysis, security hardening |
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -38,6 +38,9 @@ description: "Production-grade Go development patterns for building resilient se
 | `references/testing.md` | Test strategies, build tags, table-driven tests |
 | `references/linting.md` | golangci-lint v2, staticcheck, code quality |
 | `references/api-design.md` | Bitmask options, functional options, builders |
+| `references/fuzz-testing.md` | Go fuzzing patterns, security seeds |
+| `references/mutation-testing.md` | Gremlins configuration, test quality measurement |
+| `references/makefile.md` | Standard Makefile interface for CI/CD |
 
 ## Package Structure
 
@@ -109,6 +112,27 @@ return fmt.Errorf("failed to process: %w", err)
 ```
 
 See reference files for complete patterns and examples.
+
+## Related Skills
+
+This skill is the primary entry point for Go development. For complete project setup, coordinate with:
+
+| Task | Skill |
+|------|-------|
+| Repository setup, branch protection, auto-merge | `github-project` |
+| OpenSSF Scorecard, SLSA provenance, signed releases | `enterprise-readiness` |
+| Security audits (OWASP, CVE analysis) | `security-audit` |
+
+### Workflow
+
+```
+go-development (this skill)
+├── Code quality: linting, testing, fuzzing
+├── Standard Makefile: test, build, lint, fuzz
+└── Delegates to:
+    ├── github-project → repo setup, CI workflows, branch protection
+    └── enterprise-readiness → supply chain security, SLSA, signing
+```
 
 ---
 

--- a/references/fuzz-testing.md
+++ b/references/fuzz-testing.md
@@ -1,0 +1,152 @@
+# Go Fuzz Testing
+
+Go 1.18+ includes built-in fuzzing support. This guide covers patterns for security-focused fuzz testing.
+
+## When to Use Fuzz Testing
+
+- Input parsing (URLs, queries, content types)
+- Data validation and sanitization
+- Security-sensitive operations (XSS prevention, path traversal detection)
+- Protocol handling and serialization
+- Cache key generation
+
+## Basic Pattern
+
+```go
+//go:build fuzz
+
+package mypackage
+
+import (
+    "testing"
+    "unicode/utf8"
+)
+
+func FuzzMyFunction(f *testing.F) {
+    // 1. Seed with known edge cases
+    f.Add("normal input")
+    f.Add("")                    // Empty
+    f.Add("\x00null")            // Null bytes
+    f.Add("../../../etc/passwd") // Path traversal
+    f.Add("<script>alert(1)")    // XSS attempt
+    f.Add("' OR 1=1--")          // SQL injection
+
+    // 2. Define the fuzz target
+    f.Fuzz(func(t *testing.T, input string) {
+        // Skip invalid UTF-8 if needed
+        if !utf8.ValidString(input) {
+            return
+        }
+
+        // Exercise the function - should not panic
+        result, err := MyFunction(input)
+
+        // Validate invariants
+        if err == nil {
+            // Check properties that should always hold
+            if result == nil {
+                t.Error("nil result without error")
+            }
+        }
+    })
+}
+```
+
+## Security-Focused Seeds
+
+### URL/Path Handling
+
+```go
+f.Add("/users")
+f.Add("/users/john%20doe")
+f.Add("/%2e%2e/etc/passwd")          // Path traversal
+f.Add("/%00null")                    // Null byte injection
+f.Add("/users/../../../etc/passwd")  // Directory traversal
+f.Add("/%252e%252e/")                // Double encoding
+f.Add("/路径/用户")                   // Unicode paths
+f.Add("//double//slashes//")
+f.Add("/users;id")                   // Command injection
+f.Add("/users|ls")                   // Pipe injection
+```
+
+### Query Parameters
+
+```go
+f.Add("key=value")
+f.Add("key=")
+f.Add("=value")
+f.Add("key")
+f.Add("")
+f.Add("key=value&key=value2")        // Duplicate keys
+f.Add("key=%00")                     // Null byte
+f.Add("key=<script>")                // XSS
+f.Add("key=' OR 1=1--")              // SQL injection
+f.Add("key[]=value1&key[]=value2")   // Array syntax
+```
+
+### XSS Payloads
+
+```go
+f.Add("<script>alert(1)</script>")
+f.Add("<img src=x onerror=alert(1)>")
+f.Add("javascript:alert(1)")
+f.Add("<svg onload=alert(1)>")
+f.Add("{{.}}")                       // Template injection
+f.Add("${7*7}")                      // Expression injection
+```
+
+## Running Fuzz Tests
+
+```bash
+# Run specific fuzz test (30 seconds)
+go test -fuzz=FuzzMyFunction -fuzztime=30s ./...
+
+# Run all fuzz tests in package
+go test -fuzz=. -fuzztime=1m ./path/to/package
+
+# Run with race detector (slower but thorough)
+go test -fuzz=FuzzMyFunction -fuzztime=30s -race ./...
+
+# Reproduce a failing case from testdata
+go test -run=FuzzMyFunction/failing_case ./...
+```
+
+## CI Integration
+
+Add to Makefile:
+
+```makefile
+.PHONY: fuzz
+fuzz:
+	@echo "Running fuzz tests..."
+	@for pkg in $$(go list ./... | grep -v /vendor/); do \
+		for fuzz in $$(go test -list='^Fuzz' $$pkg 2>/dev/null | grep '^Fuzz'); do \
+			echo "Fuzzing $$fuzz in $$pkg..."; \
+			go test -fuzz=$$fuzz -fuzztime=30s $$pkg || exit 1; \
+		done; \
+	done
+```
+
+## Best Practices
+
+1. **Use Build Tags**: Isolate fuzz tests with `//go:build fuzz`
+2. **Seed Edge Cases**: Include security payloads, boundary values, unicode
+3. **Validate UTF-8**: Skip invalid strings early if your code expects valid UTF-8
+4. **Check Invariants**: Assert properties that should always hold
+5. **No Panics**: Primary goal is proving code doesn't panic on any input
+6. **Limit Resource Usage**: Skip extremely long inputs to prevent timeouts
+
+## File Organization
+
+```
+package/
+├── handler.go
+├── handler_test.go       # Unit tests
+└── handler_fuzz_test.go  # Fuzz tests (//go:build fuzz)
+```
+
+## Related
+
+- [Go Fuzzing Documentation](https://go.dev/security/fuzz/)
+- `references/testing.md` - General testing patterns
+- `references/mutation-testing.md` - Complementary test quality measurement

--- a/references/makefile.md
+++ b/references/makefile.md
@@ -1,0 +1,166 @@
+# Standard Makefile Interface
+
+A consistent Makefile interface enables CI/CD automation and cross-project tooling. This defines the standard targets every Go project should implement.
+
+## Required Targets
+
+| Target | Description | Exit Code |
+|--------|-------------|-----------|
+| `make test` | Run tests with race detection and coverage | 0 on pass, 1 on fail |
+| `make build` | Build the application binary | 0 on success |
+| `make lint` | Run golangci-lint | 0 on pass, 1 on issues |
+
+## Recommended Targets
+
+| Target | Description |
+|--------|-------------|
+| `make fuzz` | Run fuzz tests (30s per target) |
+| `make vuln-check` | Run govulncheck |
+| `make security` | Run security checks (gosec, gitleaks) |
+| `make all` | lint + test + build |
+| `make clean` | Remove build artifacts |
+| `make fmt` | Format code |
+| `make setup` | Install dependencies and tools |
+| `make dev-check` | Pre-commit quality gates |
+
+## Template
+
+```makefile
+# Project Makefile
+# Implements standard interface for CI/CD compatibility
+
+# Build configuration
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_TIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS := -s -w -X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)'
+BUILDFLAGS := -ldflags="$(LDFLAGS)" -trimpath
+
+# Coverage settings
+COVERAGE_THRESHOLD := 80
+COVERAGE_FILE := coverage.out
+
+.DEFAULT_GOAL := all
+
+# =============================================================================
+# STANDARD INTERFACE (Required)
+# =============================================================================
+
+.PHONY: all
+all: lint test build
+
+.PHONY: test
+test: ## Run tests with race detection and coverage
+	@go test -race -coverprofile=$(COVERAGE_FILE) -covermode=atomic ./...
+	@go tool cover -func=$(COVERAGE_FILE) | tail -n 1
+
+.PHONY: build
+build: ## Build the application binary
+	@CGO_ENABLED=0 go build $(BUILDFLAGS) -o bin/app ./cmd/app
+
+.PHONY: lint
+lint: ## Run golangci-lint
+	@golangci-lint run --timeout 5m
+
+# =============================================================================
+# RECOMMENDED TARGETS
+# =============================================================================
+
+.PHONY: fuzz
+fuzz: ## Run fuzz tests (30s per target)
+	@for pkg in $$(go list ./... | grep -v /vendor/); do \
+		for fuzz in $$(go test -list='^Fuzz' $$pkg 2>/dev/null | grep '^Fuzz'); do \
+			echo "Fuzzing $$fuzz in $$pkg..."; \
+			go test -fuzz=$$fuzz -fuzztime=30s $$pkg || exit 1; \
+		done; \
+	done
+
+.PHONY: vuln-check
+vuln-check: ## Run govulncheck
+	@go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+.PHONY: security
+security: ## Run security checks (gosec, gitleaks)
+	@gosec ./...
+	@gitleaks detect
+
+.PHONY: fmt
+fmt: ## Format code
+	@gofmt -w $$(git ls-files '*.go')
+	@goimports -w $$(git ls-files '*.go')
+
+.PHONY: vet
+vet: ## Run go vet
+	@go vet ./...
+
+.PHONY: clean
+clean: ## Remove build artifacts
+	@rm -rf bin/ $(COVERAGE_FILE) coverage-reports/
+
+.PHONY: setup
+setup: ## Install dependencies and tools
+	@go mod download
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@go install golang.org/x/vuln/cmd/govulncheck@latest
+
+.PHONY: dev-check
+dev-check: fmt vet lint security test ## Pre-commit quality gates
+	@echo "All checks passed!"
+
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+```
+
+## CI Integration
+
+The standard interface enables simple CI workflows:
+
+```yaml
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make lint
+      - run: make test
+      - run: make build
+```
+
+## Coverage Enforcement
+
+```makefile
+.PHONY: test-coverage
+test-coverage: test
+	@COVERAGE=$$(go tool cover -func=$(COVERAGE_FILE) | grep "^total:" | awk '{print $$3}' | sed 's/%//'); \
+	if [ "$${COVERAGE%.*}" -lt "$(COVERAGE_THRESHOLD)" ]; then \
+		echo "Coverage $${COVERAGE}% below threshold $(COVERAGE_THRESHOLD)%"; \
+		exit 1; \
+	fi
+```
+
+## Docker Integration
+
+```makefile
+DOCKER_IMAGE := myapp
+DOCKER_TAG := $(VERSION)
+
+.PHONY: docker-build
+docker-build: ## Build Docker image
+	@docker build -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
+
+.PHONY: docker-test
+docker-test: ## Run tests in Docker
+	@docker run --rm $(DOCKER_IMAGE):$(DOCKER_TAG) make test
+```
+
+## Related
+
+- `references/linting.md` - golangci-lint configuration
+- `references/testing.md` - Testing patterns
+- `references/fuzz-testing.md` - Fuzz testing setup
+- `references/mutation-testing.md` - Mutation testing setup

--- a/references/mutation-testing.md
+++ b/references/mutation-testing.md
@@ -1,0 +1,190 @@
+# Go Mutation Testing
+
+Mutation testing measures test quality by introducing small code changes (mutations) and verifying tests detect them. Higher scores indicate more effective tests.
+
+## Tool: Gremlins
+
+[go-gremlins](https://github.com/go-gremlins/gremlins) is the recommended mutation testing tool for Go.
+
+```bash
+# Install
+go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
+
+# Run
+gremlins unleash --config=.gremlins.yaml
+```
+
+## Configuration
+
+Create `.gremlins.yaml` in project root:
+
+```yaml
+# Packages to test
+test-packages:
+  - .
+  - ./cmd/...
+  - ./internal/...
+
+# Mutator types to enable
+mutators:
+  - CONDITIONALS_BOUNDARY    # Change < to <=, > to >=
+  - CONDITIONALS_NEGATION    # Negate conditions (== to !=)
+  - INCREMENT_DECREMENT      # Change ++ to --
+  - INVERT_LOGICAL           # Invert && to ||
+  - INVERT_NEGATIVES         # Remove negation operators
+  - INVERT_LOOPCTRL          # Change break to continue
+
+# Files/patterns to exclude
+exclude:
+  - "**/*_test.go"           # Test files
+  - "**/test/**"             # Test helpers
+  - "**/mock/**"             # Mock implementations
+  - "**/generated/**"        # Generated code
+
+# Only mutate code covered by tests
+coverage: true
+
+# Minimum acceptable mutation score (%)
+threshold: 60
+
+# Timeout multiplier for test runs
+timeout-coefficient: 5
+
+# Output reports
+output:
+  json: mutation-report.json
+  html: mutation-report.html
+
+# Test timeout
+test-timeout: 120s
+```
+
+## Understanding Results
+
+| Metric | Meaning |
+|--------|---------|
+| **Killed** | Tests detected the mutation (good!) |
+| **Survived** | Tests missed the mutation (needs improvement) |
+| **Timed Out** | Tests hung on mutation (usually killed) |
+| **Skipped** | Excluded from analysis |
+
+**Test Efficacy** = (Killed + Timed Out) / Total Mutations
+
+Target: **60%+ for production code**
+
+## CI Integration
+
+### GitHub Actions Workflow
+
+```yaml
+name: Mutation Testing
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '**.go'
+      - '.gremlins.yaml'
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install gremlins
+        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
+
+      - name: Run mutation tests
+        run: |
+          gremlins unleash --config=.gremlins.yaml 2>&1 | tee output.txt
+          SCORE=$(grep -oP 'Test efficacy: \K[\d.]+' output.txt || echo "0")
+          echo "Mutation Score: ${SCORE}%"
+          if (( $(echo "$SCORE < 60" | bc -l) )); then
+            echo "::warning::Mutation score below 60%"
+          fi
+
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-reports
+          path: |
+            mutation-report.json
+            mutation-report.html
+```
+
+### Diff-Based Testing (PRs only)
+
+For efficiency, only test mutations in changed files on PRs:
+
+```yaml
+- name: Run mutation tests (diff only)
+  if: github.event_name == 'pull_request'
+  run: |
+    BASE_REF="${{ github.event.pull_request.base.sha }}"
+    gremlins unleash --config=.gremlins.yaml --diff "$BASE_REF"
+```
+
+## Makefile Integration
+
+```makefile
+.PHONY: mutation
+mutation:
+	@echo "Running mutation tests..."
+	@gremlins unleash --config=.gremlins.yaml
+
+.PHONY: mutation-report
+mutation-report: mutation
+	@echo "Opening mutation report..."
+	@open mutation-report.html 2>/dev/null || xdg-open mutation-report.html
+```
+
+## Improving Mutation Score
+
+### Common Surviving Mutations
+
+1. **Boundary conditions** - Add tests for `<` vs `<=`, `>` vs `>=`
+2. **Error paths** - Test both success and failure cases
+3. **Loop controls** - Verify break/continue behavior
+4. **Negation** - Test both true and false conditions
+5. **Increment/Decrement** - Check exact values, not just "changed"
+
+### Example: Fixing a Survivor
+
+```go
+// Original code
+func IsValid(x int) bool {
+    return x > 0  // Mutation: x >= 0 survives
+}
+
+// Original test (insufficient)
+func TestIsValid(t *testing.T) {
+    assert.True(t, IsValid(1))   // x > 0 and x >= 0 both pass
+    assert.False(t, IsValid(-1)) // x > 0 and x >= 0 both fail
+}
+
+// Fixed test (kills the mutation)
+func TestIsValid(t *testing.T) {
+    assert.True(t, IsValid(1))
+    assert.False(t, IsValid(-1))
+    assert.False(t, IsValid(0))  // Boundary case kills x >= 0
+}
+```
+
+## Best Practices
+
+1. **Start with 60% threshold** - Increase as tests mature
+2. **Exclude generated code** - Focus on hand-written logic
+3. **Use coverage mode** - Only mutate tested code
+4. **Run on CI** - Catch regressions early
+5. **Diff mode for PRs** - Full runs on main branch only
+
+## Related
+
+- `references/testing.md` - General testing patterns
+- `references/fuzz-testing.md` - Complementary input validation testing
+- [go-gremlins documentation](https://github.com/go-gremlins/gremlins)


### PR DESCRIPTION
## Summary

- Add `references/fuzz-testing.md` with Go fuzzing patterns and security seeds
- Add `references/mutation-testing.md` with Gremlins configuration guide
- Add `references/makefile.md` with standard Makefile interface for CI/CD
- Update SKILL.md with new references and Related Skills delegation section
- Update README.md with complete reference list and Related Skills section

## Skill Unification

This is part of a broader skill unification effort to ensure any Go project can reach the same level of professionalism as ldap-manager, go-cron, and ofelia.

### Hub-and-Spoke Model

```
go-development (this skill)
├── Code quality: linting, testing, fuzzing
├── Standard Makefile: test, build, lint, fuzz
└── Delegates to:
    ├── github-project → repo setup, CI workflows, branch protection
    └── enterprise-readiness → supply chain security, SLSA, signing
```

## New Reference Files

| File | Purpose |
|------|---------|
| `references/fuzz-testing.md` | Go fuzzing patterns, security seed examples |
| `references/mutation-testing.md` | Gremlins setup, CI integration |
| `references/makefile.md` | Standard interface: `make test`, `make build`, `make lint` |

## Test Plan

- [ ] Verify reference files render correctly
- [ ] Run skill against a Go project