### PR TITLE
fix: align SKILL.md description with quality standard

### DIFF
--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-development
-description: "Use when developing Go applications, implementing job schedulers, Docker integrations, LDAP clients, or needing patterns for resilience, testing, and performance optimization."
+description: "Use when developing Go applications, implementing job schedulers, Docker integrations, LDAP clients, or building resilient services with thorough testing and performance optimization."
 ---
 
 # Go Development Patterns

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-development
-description: "Production-grade Go development patterns for building resilient services. Use when developing Go applications, implementing job schedulers, Docker integrations, LDAP clients, or needing patterns for resilience, testing, and performance optimization. By Netresearch."
+description: "Use when developing Go applications, implementing job schedulers, Docker integrations, LDAP clients, or needing patterns for resilience, testing, and performance optimization."
 ---
 
 # Go Development Patterns


### PR DESCRIPTION
## Summary
- Fix SKILL.md description to use "Use when..." trigger format
- Remove "Agent Skill:" prefix and "By Netresearch." suffix
- Remove workflow summaries from description

Addresses netresearch/claude-code-marketplace#32