### PR TITLE
feat: add Go 1.26 modernization patterns

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-development",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Production-grade Go development patterns for resilient services",
   "repository": "https://github.com/netresearch/go-development-skill",
   "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ go-development-skill/
     ├── api-design.md                     # Bitmask options, functional options
     ├── fuzz-testing.md                   # Go fuzzing patterns, security seeds
     ├── mutation-testing.md               # Gremlins test quality measurement
-    └── makefile.md                       # Standard Makefile interface
+    ├── makefile.md                       # Standard Makefile interface
+    └── modernization.md                  # Go 1.26 modernizers, go fix, errors.AsType
 ```
 
 ## Expertise Areas

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -28,8 +28,9 @@ A Go development review is NOT complete until all related skills have been execu
 
 ### Type Safety
 
-- **Avoid:** `interface{}`, `sync.Map`, scattered type assertions, reflection
-- **Prefer:** Generics `[T any]`, concrete types, compile-time verification
+- **Avoid:** `interface{}` (use `any`), `sync.Map`, scattered type assertions, reflection, `errors.As` with pre-declared variables
+- **Prefer:** Generics `[T any]`, `errors.AsType[T]` (Go 1.26), concrete types, compile-time verification
+- **Modernize:** Run `go fix ./...` after Go upgrades to apply automated modernizers
 
 ### Consistency
 
@@ -60,6 +61,7 @@ Load these as needed for detailed patterns and examples:
 | `references/fuzz-testing.md` | Go fuzzing patterns, security seeds |
 | `references/mutation-testing.md` | Gremlins configuration, test quality measurement |
 | `references/makefile.md` | Standard Makefile interface for CI/CD |
+| `references/modernization.md` | Go 1.26 modernizers, `go fix`, `errors.AsType[T]`, `wg.Go()` |
 
 ## Quality Gates
 

--- a/skills/go-development/references/api-design.md
+++ b/skills/go-development/references/api-design.md
@@ -289,13 +289,12 @@ var (
     ErrInvalidFormat = &ValidationError{Message: "invalid format"}
 )
 
-// Usage with errors.Is/As
+// Usage with errors.Is/AsType (Go 1.26+)
 if errors.Is(err, ErrEmptySpec) {
     // Handle empty spec
 }
 
-var validationErr *ValidationError
-if errors.As(err, &validationErr) {
+if validationErr, ok := errors.AsType[*ValidationError](err); ok {
     fmt.Printf("Field %s is invalid: %s\n", validationErr.Field, validationErr.Value)
 }
 ```

--- a/skills/go-development/references/architecture.md
+++ b/skills/go-development/references/architecture.md
@@ -452,12 +452,11 @@ func (e *ValidationError) Error() string {
     return fmt.Sprintf("validation failed for %s: %s", e.Field, e.Message)
 }
 
-// Error checking
+// Error checking (Go 1.26+: use errors.AsType for type-safe extraction)
 func HandleJob(name string) error {
     job, err := scheduler.GetJob(name)
     if err != nil {
-        var notFound *JobNotFoundError
-        if errors.As(err, &notFound) {
+        if _, ok := errors.AsType[*JobNotFoundError](err); ok {
             // Handle not found
             return nil
         }

--- a/skills/go-development/references/docker.md
+++ b/skills/go-development/references/docker.md
@@ -35,7 +35,7 @@ func NewOptimizedDockerClient(endpoint string) (*OptimizedDockerClient, error) {
         client:   client,
         endpoint: endpoint,
         bufferPool: &sync.Pool{
-            New: func() interface{} {
+            New: func() any {
                 return NewCircularBuffer(64 * 1024) // 64KB buffers
             },
         },
@@ -51,7 +51,7 @@ func NewOptimizedDockerClientFromEnv() (*OptimizedDockerClient, error) {
     return &OptimizedDockerClient{
         client: client,
         bufferPool: &sync.Pool{
-            New: func() interface{} {
+            New: func() any {
                 return NewCircularBuffer(64 * 1024)
             },
         },

--- a/skills/go-development/references/linting.md
+++ b/skills/go-development/references/linting.md
@@ -48,7 +48,7 @@ linters:
     - revive          # Fast, configurable linter
     - gocritic        # Opinionated linter
 
-    # Modernization (Go 1.21+)
+    # Modernization (Go 1.22+)
     - intrange        # Use for range n
     - usestdlibvars   # Use http.StatusOK instead of 200
     - modernize       # Modern Go features
@@ -201,6 +201,21 @@ type ValidationFailed struct{}                  // Should end with Error
 var ErrInvalidInput = errors.New("invalid input")
 type ValidationError struct{}
 ```
+
+## go fix — Automated Modernization (Go 1.26+)
+
+Go 1.26 ships a rewritten `go fix` with 22 built-in modernizers. Run after Go upgrades:
+
+```bash
+go fix -diff ./...    # Preview changes
+go fix ./...          # Apply changes
+```
+
+Key modernizers: `any`, `rangeint`, `slicescontains`, `mapsloop`, `minmax`, `waitgroup`, `testingcontext`, `reflecttypefor`, `stringscutprefix`, `stringsseq`, `stringsbuilder`.
+
+**Always run linters after `go fix`** — it may leave unused imports, redundant variables, or gofumpt issues.
+
+See `references/modernization.md` for the full modernizer reference and manual migrations like `errors.AsType[T]`.
 
 ## Running Linters
 

--- a/skills/go-development/references/modernization.md
+++ b/skills/go-development/references/modernization.md
@@ -1,0 +1,278 @@
+# Go Modernization Patterns
+
+## go fix — Automated Code Modernization
+
+Go 1.26 ships a rewritten `go fix` with 22 built-in modernizers. Run it on any codebase to apply idiomatic Go patterns automatically.
+
+### Running go fix
+
+```bash
+# Apply all applicable modernizers
+go fix ./...
+
+# Preview changes without applying (dry run)
+go fix -diff ./...
+
+# Apply specific modernizer only
+go fix -fix=any ./...
+```
+
+### Modernizer Reference
+
+| Modernizer | What it does | Example |
+|------------|-------------|---------|
+| `any` | `interface{}` → `any` | `func Foo(x interface{})` → `func Foo(x any)` |
+| `rangeint` | C-style loops → range | `for i := 0; i < n; i++` → `for i := range n` |
+| `slicescontains` | Manual contains loops → `slices.Contains()` | Loop+compare → `slices.Contains(s, v)` |
+| `mapsloop` | Manual map copy → `maps.Copy()` | for+assign → `maps.Copy(dst, src)` |
+| `minmax` | if/else capping → `min()`/`max()` builtins | if/else block → `min(a, b)` |
+| `stringscutprefix` | `HasPrefix`+`TrimPrefix` → `CutPrefix` | Two calls → `strings.CutPrefix(s, p)` |
+| `stringsseq` | `range strings.Split()` → `SplitSeq()` | Avoids allocating intermediate slice |
+| `waitgroup` | `wg.Add(1)/go/defer wg.Done()` → `wg.Go()` | Three lines → `wg.Go(func() { ... })` |
+| `testingcontext` | `context.WithCancel(context.Background())` → `t.Context()` | In tests only |
+| `reflecttypefor` | `reflect.TypeOf((*T)(nil)).Elem()` → `reflect.TypeFor[T]()` | Cleaner generic form |
+| `stringsbuilder` | `output += s` → `strings.Builder` | Better performance for string concatenation |
+
+### go fix Best Practices
+
+1. **Run after upgrading Go** — `go fix` detects your `go.mod` version and only applies applicable modernizers
+2. **Review the diff** — Use `go fix -diff ./...` first to understand what changes will be made
+3. **Run linters after** — `go fix` may leave behind unused imports, redundant variables, or gofumpt issues
+4. **Commit separately** — Keep `go fix` changes in their own commit for clean history
+
+### Common Post-fix Cleanup
+
+After `go fix`, watch for:
+
+```go
+// go fix may leave redundant loop variable copies (Go 1.22+)
+for field := range t.Fields() {
+    field := field  // ← delete this (copyloopvar lint)
+    // ...
+}
+
+// go fix may inline helpers and leave them unused
+//go:fix inline
+func stringPtr(s string) *string {  // ← delete if unused
+    return new(s)
+}
+```
+
+## errors.AsType[T] (Go 1.26)
+
+Go 1.26 adds `errors.AsType[T]` — a type-safe generic replacement for `errors.As` that eliminates pre-declared target variables.
+
+### Before (errors.As)
+
+```go
+var flagErr *flags.Error
+if errors.As(err, &flagErr) {
+    if flagErr.Type == flags.ErrHelp {
+        return
+    }
+}
+```
+
+### After (errors.AsType)
+
+```go
+if flagErr, ok := errors.AsType[*flags.Error](err); ok {
+    if flagErr.Type == flags.ErrHelp {
+        return
+    }
+}
+```
+
+### Common Conversion Patterns
+
+**Positive check with value use:**
+```go
+// Before
+var exitErr NonZeroExitError
+if errors.As(err, &exitErr) {
+    log.Printf("exit code: %d", exitErr.ExitCode)
+}
+
+// After
+if exitErr, ok := errors.AsType[NonZeroExitError](err); ok {
+    log.Printf("exit code: %d", exitErr.ExitCode)
+}
+```
+
+**Negative check (guard clause):**
+```go
+// Before
+var validationErrors validator.ValidationErrors
+if !errors.As(err, &validationErrors) {
+    return fmt.Errorf("unexpected error: %w", err)
+}
+
+// After
+validationErrors, ok := errors.AsType[validator.ValidationErrors](err)
+if !ok {
+    return fmt.Errorf("unexpected error: %w", err)
+}
+```
+
+**Bool-only check (discard value):**
+```go
+// Before
+func IsNonZeroExitError(err error) bool {
+    var exitErr NonZeroExitError
+    return errors.As(err, &exitErr)
+}
+
+// After
+func IsNonZeroExitError(err error) bool {
+    _, ok := errors.AsType[NonZeroExitError](err)
+    return ok
+}
+```
+
+### Why errors.AsType is Better
+
+| `errors.As` | `errors.AsType[T]` |
+|---|---|
+| Requires pre-declared target variable | No variable declaration needed |
+| Type safety checked at runtime | Type checked at compile time |
+| `errors.As(err, &target)` — pointer indirection | `errors.AsType[T](err)` — direct generic |
+| Target variable leaks into outer scope | Scoped to `if` block with `:=` |
+
+### Migration
+
+`go fix` does NOT automatically convert `errors.As` → `errors.AsType`. This is a manual migration. Search for all occurrences:
+
+```bash
+grep -rn 'errors\.As(' --include='*.go' .
+```
+
+## sync.WaitGroup.Go (Go 1.25)
+
+`sync.WaitGroup` gained a `Go` method that combines `Add(1)`, goroutine launch, and `defer Done()`:
+
+```go
+// Before
+var wg sync.WaitGroup
+for range 20 {
+    wg.Add(1)
+    go func() {
+        defer wg.Done()
+        doWork()
+    }()
+}
+wg.Wait()
+
+// After
+var wg sync.WaitGroup
+for range 20 {
+    wg.Go(func() {
+        doWork()
+    })
+}
+wg.Wait()
+```
+
+`go fix` handles this conversion automatically via the `waitgroup` modernizer.
+
+## new(expr) — Pointer to Value (Go 1.26)
+
+Go 1.26 extends `new()` to accept expressions (not just types), returning a pointer to a copy:
+
+```go
+// Before — temporary variable needed
+func stringPtr(s string) *string {
+    return &s
+}
+
+// After — direct construction
+p := new("hello")  // *string pointing to "hello"
+n := new(42)       // *int pointing to 42
+```
+
+`go fix` can inline helper functions annotated with `//go:fix inline` that follow this pattern.
+
+## for range n (Go 1.22)
+
+Integer range loops replace C-style counting:
+
+```go
+// Before
+for i := 0; i < 10; i++ {
+    fmt.Println(i)
+}
+
+// After
+for i := range 10 {
+    fmt.Println(i)
+}
+
+// When index is unused
+for range 10 {
+    doSomething()
+}
+```
+
+## Loop Variable Capture Fix (Go 1.22)
+
+Go 1.22 fixed loop variable capture — the `tt := tt` shadow is no longer needed:
+
+```go
+// Before (Go < 1.22) — required to prevent capture bug
+for _, tt := range tests {
+    tt := tt  // ← was needed
+    t.Run(tt.name, func(t *testing.T) {
+        t.Parallel()
+        // ...
+    })
+}
+
+// After (Go 1.22+) — safe without shadow
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        t.Parallel()
+        // ...
+    })
+}
+```
+
+The `copyloopvar` linter flags unnecessary copies.
+
+## t.Context() (Go 1.24)
+
+Tests can use `t.Context()` instead of manually creating background contexts:
+
+```go
+// Before
+func TestSomething(t *testing.T) {
+    ctx, cancel := context.WithCancel(context.Background())
+    defer cancel()
+    // use ctx...
+}
+
+// After
+func TestSomething(t *testing.T) {
+    ctx := t.Context()  // cancelled automatically when test ends
+    // use ctx...
+}
+```
+
+`go fix` handles this via the `testingcontext` modernizer.
+
+## Version-Gated Features Summary
+
+| Feature | Minimum Go | go fix? |
+|---------|-----------|---------|
+| `any` keyword | 1.18 | Yes |
+| Generics | 1.18 | N/A |
+| `for range n` | 1.22 | Yes |
+| Loop variable fix | 1.22 | N/A |
+| `min()`/`max()` builtins | 1.21 | Yes |
+| `slices.Contains()` | 1.21 | Yes |
+| `maps.Copy()` | 1.21 | Yes |
+| `strings.CutPrefix()` | 1.20 | Yes |
+| `t.Context()` | 1.24 | Yes |
+| `sync.WaitGroup.Go()` | 1.25 | Yes |
+| `strings.SplitSeq()` | 1.25 | Yes |
+| `errors.AsType[T]()` | 1.26 | No (manual) |
+| `new(expr)` | 1.26 | Yes |
+| `reflect.TypeFor[T]()` | 1.22 | Yes |

--- a/skills/go-development/references/testing.md
+++ b/skills/go-development/references/testing.md
@@ -672,7 +672,7 @@ func BenchmarkJobExecution(b *testing.B) {
     ctx := context.Background()
 
     b.ResetTimer()
-    for i := 0; i < b.N; i++ {
+    for range b.N {
         job.Run(ctx)
     }
 }
@@ -681,7 +681,7 @@ func BenchmarkParseSchedule(b *testing.B) {
     schedule := "*/5 * * * *"
 
     b.ResetTimer()
-    for i := 0; i < b.N; i++ {
+    for range b.N {
         ParseSchedule(schedule)
     }
 }
@@ -803,7 +803,6 @@ func TestParseConfig(t *testing.T) {
     }
 
     for _, tt := range tests {
-        tt := tt // Capture range variable (required for parallel subtests)
         t.Run(tt.name, func(t *testing.T) {
             t.Parallel() // Subtests can also be parallel
 
@@ -842,7 +841,6 @@ func TestWithSharedSetup(t *testing.T) {
     }
 
     for _, tt := range tests {
-        tt := tt
         t.Run(tt.name, func(t *testing.T) {
             t.Parallel()
             resp := server.Get(tt.endpoint)
@@ -916,27 +914,16 @@ func (c *Cache) Get(k string) string {
 
 **2. Goroutine capturing loop variable:**
 
+> **Note:** Go 1.22+ fixed loop variable capture. The `i := i` shadow is no longer needed.
+> The examples below show the modern style.
+
 ```go
-// BAD: All goroutines see final value of i
-for i := 0; i < 10; i++ {
+// Modern Go (1.22+): safe without shadow
+for i := range 10 {
     go func() {
-        fmt.Println(i) // Race! Prints 10 ten times
+        fmt.Println(i) // Safe: each iteration gets its own copy
     }()
 }
-
-// GOOD: Capture variable
-for i := 0; i < 10; i++ {
-    i := i // Shadow the variable
-    go func() {
-        fmt.Println(i) // Safe: each goroutine has its own copy
-    }()
-}
-
-// GOOD: Pass as argument
-for i := 0; i < 10; i++ {
-    go func(n int) {
-        fmt.Println(n)
-    }(i)
 }
 ```
 


### PR DESCRIPTION
## Summary

- Add new `references/modernization.md` covering Go 1.26 `go fix` (22 modernizers), `errors.AsType[T]`, `sync.WaitGroup.Go()`, `new(expr)`, `for range n`, loop variable fix, `t.Context()`, and a version-gated features summary table
- Update all existing reference code examples to use modern Go patterns: `errors.AsType[T]`, `any`, `for range n`, remove `tt := tt` captures
- Add `go fix` section to linting reference
- Bump version to 1.4.0

## Motivation

Go 1.26 (Feb 2026) introduced the rewritten `go fix` with 22 automated modernizers and `errors.AsType[T]`. The skill's code examples should reflect current best practices. Validated by applying these patterns to the [Ofelia codebase](https://github.com/netresearch/ofelia/pull/475) (77 files modernized).

## Changes

| File | Change |
|------|--------|
| `references/modernization.md` | **New** — Complete Go 1.26 modernization guide |
| `SKILL.md` | Updated type safety guidance, added reference link |
| `references/architecture.md` | `errors.As` → `errors.AsType[T]` |
| `references/api-design.md` | `errors.As` → `errors.AsType[T]` |
| `references/resilience.md` | `errors.As` → `errors.AsType[T]`, `for range n` |
| `references/docker.md` | `interface{}` → `any` in sync.Pool |
| `references/testing.md` | Remove `tt := tt`, `for range b.N`, modern goroutine patterns |
| `references/linting.md` | Add `go fix` section |
| `plugin.json` | Version 1.3.0 → 1.4.0 |
| `README.md` | Add modernization.md to structure |

## Test plan

- [ ] Verify all code examples compile conceptually
- [ ] Review modernization.md for completeness and accuracy
- [ ] Check no duplicate linter entries in linting.md