### PR TITLE
docs(linting): add stdlib naming conflicts and CI version drift patterns

### DIFF
--- a/skills/go-development/references/linting.md
+++ b/skills/go-development/references/linting.md
@@ -202,6 +202,47 @@ var ErrInvalidInput = errors.New("invalid input")
 type ValidationError struct{}
 ```
 
+### revive var-naming: Stdlib Package Name Conflicts
+
+The `var-naming` rule flags package names that conflict with Go stdlib packages.
+Common conflicts and safe alternatives:
+
+| Avoid | Conflicts with | Use instead |
+|-------|---------------|-------------|
+| `rpc` | `net/rpc` | `rpchandler`, `rpcapi` |
+| `jsonrpc` | `net/rpc/jsonrpc` | `rpchandler` |
+| `http` | `net/http` | `httputil`, `server` |
+| `log` | `log` | `logger`, `logging` |
+
+Check with: `go list std | grep -w <name>`
+
+Also verify type names don't stutter after rename:
+
+```go
+// BAD - stutters: rpchandler.JSONRPCResponse
+type JSONRPCResponse struct { ... }
+
+// GOOD - clean: rpchandler.Response
+type Response struct { ... }
+```
+
+### golangci-lint CI vs Local Version Drift
+
+When CI uses `version: latest` in the golangci-lint-action, linter behavior
+may differ from local runs:
+
+- gosec rules (e.g., G704 SSRF) may fire in CI but not locally due to version differences
+- Use `//nolint:gosec,nolintlint` to suppress in both environments
+- `nolintlint` complains about unused directives when the target linter doesn't fire locally
+
+```go
+// Suppresses gosec in CI and nolintlint locally when gosec doesn't fire
+resp, err := client.Do(req) //nolint:gosec,nolintlint // G704: URL is a compile-time constant
+```
+
+**Best practice**: Pin the golangci-lint version in CI to match local, or accept
+the dual-nolint pattern for edge cases.
+
 ## go fix — Automated Modernization (Go 1.26+)
 
 Go 1.26 ships a rewritten `go fix` with 22 built-in modernizers. Run after Go upgrades:

--- a/skills/go-development/references/linting.md
+++ b/skills/go-development/references/linting.md
@@ -202,7 +202,7 @@ var ErrInvalidInput = errors.New("invalid input")
 type ValidationError struct{}
 ```
 
-### revive var-naming: Stdlib Package Name Conflicts
+### revive: Stdlib Package Name Conflicts
 
 The `var-naming` rule flags package names that conflict with Go stdlib packages.
 Common conflicts and safe alternatives:
@@ -210,7 +210,7 @@ Common conflicts and safe alternatives:
 | Avoid | Conflicts with | Use instead |
 |-------|---------------|-------------|
 | `rpc` | `net/rpc` | `rpchandler`, `rpcapi` |
-| `jsonrpc` | `net/rpc/jsonrpc` | `rpchandler` |
+| `jsonrpc` | `net/rpc/jsonrpc` | `jsonrpchandler`, `jsonrpcapi` |
 | `http` | `net/http` | `httputil`, `server` |
 | `log` | `log` | `logger`, `logging` |
 
@@ -226,7 +226,7 @@ type JSONRPCResponse struct { ... }
 type Response struct { ... }
 ```
 
-### golangci-lint CI vs Local Version Drift
+### golangci-lint: CI vs Local Version Drift
 
 When CI uses `version: latest` in the golangci-lint-action, linter behavior
 may differ from local runs:


### PR DESCRIPTION
## Summary

- Add revive var-naming section documenting Go stdlib package name conflicts and safe alternatives
- Add golangci-lint CI vs local version drift section with dual-nolint pattern

Discovered while fixing lint failures in [netresearch/ldap-selfservice-password-changer#466](https://github.com/netresearch/ldap-selfservice-password-changer/pull/466) where:
- `internal/rpc` conflicted with `net/rpc` (revive var-naming)
- `internal/jsonrpc` also conflicted with `net/rpc/jsonrpc`
- gosec G704 fired in CI but not locally due to version differences

## Test plan

- [ ] Verify markdown renders correctly
- [ ] Sections placed logically within linting.md