### PR TITLE
fix: remove unsupported 'support' field from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,8 +10,5 @@
   },
   "skills": [
     "./skills/go-development"
-  ],
-  "support": {
-    "issues": "https://github.com/netresearch/go-development-skill/issues"
-  }
+  ]
 }


### PR DESCRIPTION
Remove the `support` field from `.claude-plugin/plugin.json` - it's not part of the Claude Code plugin manifest schema and causes 'invalid manifest' errors.