### PR TITLE
fix: standardize plugin.json author URL to company website

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,11 +2,11 @@
   "name": "go-development",
   "version": "1.5.1",
   "description": "Production-grade Go development patterns for resilient services",
-  "repository": "https://github.com/netresearch/go-development-skill",
+  "repository": "https://www.netresearch.de",
   "license": "MIT",
   "author": {
     "name": "Netresearch DTT GmbH",
-    "url": "https://github.com/netresearch/go-development-skill"
+    "url": "https://www.netresearch.de"
   },
   "skills": [
     "./skills/go-development"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "go-development",
   "version": "1.5.1",
   "description": "Production-grade Go development patterns for resilient services",
-  "repository": "https://www.netresearch.de",
+  "repository": "https://github.com/netresearch/go-development-skill",
   "license": "MIT",
   "author": {
     "name": "Netresearch DTT GmbH",


### PR DESCRIPTION
## Summary
- Standardize plugin.json `author.url` to company website

## Context
The `author.url` field should consistently point to `https://www.netresearch.de` (company website) across all skill repos. The `repository` field already contains the GitHub repo URL, so `author.url` should not duplicate it.