### PR TITLE
chore(release): v1.11.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-development",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Production-grade Go development patterns for resilient services",
   "repository": "https://github.com/netresearch/go-development-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires go 1.21+, golangci-lint, docker."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.11.0"
+  version: "1.11.1"
   repository: https://github.com/netresearch/go-development-skill
 allowed-tools: Bash(go:*) Bash(make:*) Bash(docker:*) Bash(golangci-lint:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
## Release v1.11.1

Patch release. Bumps `.claude-plugin/plugin.json` and `skills/go-development/SKILL.md` frontmatter `metadata.version` from `1.11.0` to `1.11.1`.

### Highlights since v1.11.0

- **CI/release-pipeline hardening**: SLSA provenance permissions granted, deprecated `with:` block and `workflow_dispatch.bump` input dropped, bump input forwarded from `workflow_dispatch` to the reusable release workflow, yamllint trailing-newline fix. No skill-content changes.

### Release plan

After merge: tag main with a signed annotated tag, push, the `skill-repo-skill` reusable workflow publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit ... --notes-file`.
