### PR TITLE
feat(references): add contracts-and-invariants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ No build system scripts defined in composer.json. Basic operations:
 - [Linting (golangci-lint)](skills/go-development/references/linting.md)
 - [API Design](skills/go-development/references/api-design.md)
 - [Fuzz Testing](skills/go-development/references/fuzz-testing.md)
+- [Contracts & Invariants](skills/go-development/references/contracts-and-invariants.md)
 - [Mutation Testing](skills/go-development/references/mutation-testing.md)
 - [Makefile Patterns](skills/go-development/references/makefile.md)
 - [Go Modernization](skills/go-development/references/modernization.md)

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -12,10 +12,6 @@ allowed-tools: Bash(go:*) Bash(make:*) Bash(docker:*) Bash(golangci-lint:*) Read
 
 # Go Development Patterns
 
-## When to Use
-
-Go services/CLIs, job scheduling, Docker API, LDAP/AD clients, resilience patterns, test suites.
-
 ## Required Workflow
 
 **For reviews, invoke related skills:** security-audit (OWASP), enterprise-readiness (OpenSSF/SLSA), github-project (branch protection). A review is NOT complete until all are executed.
@@ -65,7 +61,7 @@ Load as needed:
 | `references/linting.md` | golangci-lint v2, staticcheck, code quality |
 | `references/api-design.md` | Bitmask options, functional options, builders |
 | `references/fuzz-testing.md` | Go fuzzing patterns, security seeds |
-| `references/contracts-and-invariants.md` | Pre/postconditions, invariants, property tests with rapid/testing-quick — for state machines, protocols, concurrency, money |
+| `references/contracts-and-invariants.md` | Contracts, invariants, property tests |
 | `references/mutation-testing.md` | Gremlins configuration, test quality measurement |
 | `references/makefile.md` | Standard Makefile interface for CI/CD |
 | `references/modernization.md` | Go 1.26 modernizers, `go fix`, `errors.AsType[T]`, `wg.Go()` |

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -65,6 +65,7 @@ Load as needed:
 | `references/linting.md` | golangci-lint v2, staticcheck, code quality |
 | `references/api-design.md` | Bitmask options, functional options, builders |
 | `references/fuzz-testing.md` | Go fuzzing patterns, security seeds |
+| `references/contracts-and-invariants.md` | Pre/postconditions, invariants, property tests with rapid/testing-quick — for state machines, protocols, concurrency, money |
 | `references/mutation-testing.md` | Gremlins configuration, test quality measurement |
 | `references/makefile.md` | Standard Makefile interface for CI/CD |
 | `references/modernization.md` | Go 1.26 modernizers, `go fix`, `errors.AsType[T]`, `wg.Go()` |

--- a/skills/go-development/references/contracts-and-invariants.md
+++ b/skills/go-development/references/contracts-and-invariants.md
@@ -41,19 +41,19 @@ Document contracts inline so reviewers (and AI) see intent next to code:
 // Withdraw debits amount from the account.
 //
 // Contract:
-//   pre:  amount > 0
-//   pre:  amount <= balance
+//   pre:  amount > 0                                // caller bug if violated → panic
+//   validation: amount <= balance                   // caller's mistake → typed error
 //   post: balance == old(balance) - amount
 //   inv:  balance >= 0
 func (a *Account) Withdraw(amount Money) error {
-    assertf(amount > 0, "precondition: amount > 0, got %v", amount)
+    invariant.Assertf(amount > 0, "precondition: amount > 0, got %v", amount)
     if amount > a.balance {
         return ErrInsufficientFunds  // validation, not a contract
     }
     before := a.balance
     a.balance -= amount
-    assertf(a.balance == before-amount, "postcondition violated")
-    assertf(a.balance >= 0, "invariant: balance >= 0")
+    invariant.Assertf(a.balance == before-amount, "postcondition violated")
+    invariant.Assertf(a.balance >= 0, "invariant: balance >= 0")
     return nil
 }
 ```
@@ -92,8 +92,8 @@ For hot paths where the check itself is expensive, gate with a build tag:
 
 package invariant
 
-func Assert(cond bool, msg string)        { if !cond { panic("invariant: " + msg) } }
-func Assertf(cond bool, f string, a ...any) { if !cond { panic("invariant: " + fmt.Sprintf(f, a...)) } }
+func Assert(cond bool, msg string)                    { if !cond { panic("invariant: " + msg) } }
+func Assertf(cond bool, format string, args ...any)   { if !cond { panic("invariant: " + fmt.Sprintf(format, args...)) } }
 ```
 
 ```go
@@ -101,8 +101,8 @@ func Assertf(cond bool, f string, a ...any) { if !cond { panic("invariant: " + f
 
 package invariant
 
-func Assert(cond bool, msg string)            {}
-func Assertf(cond bool, f string, a ...any)   {}
+func Assert(cond bool, msg string)                    {}
+func Assertf(cond bool, format string, args ...any)   {}
 ```
 
 Run tests and staging with `-tags=assertions`; ship release builds without. Most code should keep checks always-on — only strip when profiling proves cost.
@@ -154,10 +154,9 @@ func TestAccount_Properties(t *testing.T) {
         ops := rapid.SliceOf(rapid.Uint32Range(0, 10_000)).Draw(t, "ops")
         for _, op := range ops {
             _ = a.Withdraw(Money(op))
-            // Invariant always holds — no need to repeat per op
-            if a.balance < 0 {
-                t.Fatalf("balance went negative: %v", a.balance)
-            }
+            // No explicit assert here: the contract inside Withdraw panics on
+            // any invariant violation, which rapid.Check surfaces with the
+            // failing input sequence.
         }
     })
 }

--- a/skills/go-development/references/contracts-and-invariants.md
+++ b/skills/go-development/references/contracts-and-invariants.md
@@ -1,0 +1,183 @@
+# Contracts & Invariants
+
+Encode preconditions, postconditions, and invariants as runtime checks in the code path. Treat them as the bridge between a spec sentence and the tests that verify it.
+
+## When to Use
+
+Use contracts where invariants are crystalline and a violation is a bug, not user error:
+
+- State machines (workflows, consensus, session lifecycle, leases)
+- Protocols (Paxos/Raft, two-phase commit, request/response correlation)
+- Concurrency primitives (locks, queues, pools, supervised goroutines)
+- Money, quantities, identifiers (never-negative, monotonic, bounded ranges)
+- Data migrations (row count preserved, no orphaned references)
+- Authorization boundaries (see security-audit-skill cross-link)
+
+## When NOT to Use
+
+- Plain CRUD glue, HTTP handler plumbing, config parsing — use input validation, not contracts
+- Anything driven by external input — that is validation (return error), not an invariant (panic)
+- Frontend/template code, doc generation, scripts
+
+A useful test: would a violation indicate the program is in an impossible state? Yes → contract. No → validation.
+
+## Contract Types
+
+| Kind | Where | If violated |
+|------|-------|-------------|
+| Precondition | First lines of a function | Caller bug — panic |
+| Postcondition | Just before `return` | Implementation bug — panic |
+| Invariant | At every public entry/exit of a stateful type | Either — panic |
+
+External-input checks are separate: return a typed error, do not panic.
+
+## Go Idioms
+
+### Doc convention
+
+Document contracts inline so reviewers (and AI) see intent next to code:
+
+```go
+// Withdraw debits amount from the account.
+//
+// Contract:
+//   pre:  amount > 0
+//   pre:  amount <= balance
+//   post: balance == old(balance) - amount
+//   inv:  balance >= 0
+func (a *Account) Withdraw(amount Money) error {
+    assertf(amount > 0, "precondition: amount > 0, got %v", amount)
+    if amount > a.balance {
+        return ErrInsufficientFunds  // validation, not a contract
+    }
+    before := a.balance
+    a.balance -= amount
+    assertf(a.balance == before-amount, "postcondition violated")
+    assertf(a.balance >= 0, "invariant: balance >= 0")
+    return nil
+}
+```
+
+### Assertion helper
+
+Keep one helper. Do not scatter ad-hoc `panic`s:
+
+```go
+// Package internal/invariant
+package invariant
+
+import "fmt"
+
+// Assert panics with msg when cond is false.
+// Use only for impossible states. Use returned errors for user input.
+func Assert(cond bool, msg string) {
+    if !cond {
+        panic("invariant: " + msg)
+    }
+}
+
+func Assertf(cond bool, format string, args ...any) {
+    if !cond {
+        panic("invariant: " + fmt.Sprintf(format, args...))
+    }
+}
+```
+
+### Strip in release (optional)
+
+For hot paths where the check itself is expensive, gate with a build tag:
+
+```go
+//go:build assertions
+
+package invariant
+
+func Assert(cond bool, msg string)        { if !cond { panic("invariant: " + msg) } }
+func Assertf(cond bool, f string, a ...any) { if !cond { panic("invariant: " + fmt.Sprintf(f, a...)) } }
+```
+
+```go
+//go:build !assertions
+
+package invariant
+
+func Assert(cond bool, msg string)            {}
+func Assertf(cond bool, f string, a ...any)   {}
+```
+
+Run tests and staging with `-tags=assertions`; ship release builds without. Most code should keep checks always-on — only strip when profiling proves cost.
+
+### Constructors fail fast
+
+Establish invariants at construction so methods can rely on them:
+
+```go
+func NewAccount(initial Money) (*Account, error) {
+    if initial < 0 {
+        return nil, fmt.Errorf("initial balance: %w", ErrNegative)
+    }
+    return &Account{balance: initial}, nil
+}
+```
+
+Validation at the boundary → typed error. Invariant inside → panic.
+
+## Property Tests from Contracts
+
+A postcondition is a property. A property test asserts the postcondition holds for many inputs.
+
+### stdlib `testing/quick` (lightweight)
+
+```go
+func TestWithdraw_PreservesNonNegativeBalance(t *testing.T) {
+    f := func(initial, amount uint32) bool {
+        a, _ := NewAccount(Money(initial))
+        _ = a.Withdraw(Money(amount))
+        return a.balance >= 0
+    }
+    if err := quick.Check(f, &quick.Config{MaxCount: 1000}); err != nil {
+        t.Fatal(err)
+    }
+}
+```
+
+### `pgregory.net/rapid` (state machines, recommended for protocols)
+
+```go
+import "pgregory.net/rapid"
+
+func TestAccount_Properties(t *testing.T) {
+    rapid.Check(t, func(t *rapid.T) {
+        initial := rapid.Uint32Range(0, 1_000_000).Draw(t, "initial")
+        a, _ := NewAccount(Money(initial))
+
+        ops := rapid.SliceOf(rapid.Uint32Range(0, 10_000)).Draw(t, "ops")
+        for _, op := range ops {
+            _ = a.Withdraw(Money(op))
+            // Invariant always holds — no need to repeat per op
+            if a.balance < 0 {
+                t.Fatalf("balance went negative: %v", a.balance)
+            }
+        }
+    })
+}
+```
+
+For protocols, model the state machine and let `rapid` drive transitions. The contract panics inside the implementation will surface any reachable invariant violation.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Panicking on user input | Return a typed error; reserve panic for impossible states |
+| Sprinkling `assert` decoratively in glue code | Gate by domain — state machines, protocols, money, authz |
+| Postcondition that re-implements the function | Postcondition states the *property*, not the steps |
+| Asserting against external systems mid-RPC | Network failure ≠ invariant violation; handle as error |
+| Catching panics from contracts to "keep serving" | Don't. An invariant violation means state is corrupt — let it crash, restart cleanly |
+
+## Cross-References
+
+- `references/testing.md` — table-driven tests, build tags
+- `references/fuzz-testing.md` — input-driven discovery (complementary to property tests)
+- `references/resilience.md` — panic recovery boundaries (only at goroutine roots, never around contracts)
+- security-audit-skill `references/authentication-patterns.md` — authorization invariants


### PR DESCRIPTION
## Summary

Adds `references/contracts-and-invariants.md` describing how to encode preconditions, postconditions, and invariants as runtime checks in the code path — and how to derive property tests from those contracts using `testing/quick` or `pgregory.net/rapid`. Wires it into the SKILL.md reference table and AGENTS.md index.

## Motivation

Inspired by [Z.-F. Huang's writeup on AI-assisted Rust development](https://zfhuang99.github.io/rust/claude%20code/codex/contracts/spec-driven%20development/2025/12/01/rust-with-ai.html), which argues contracts are the breakthrough that lets AI implement complex distributed systems correctly: the contract externalises intent in a way an AI implementer cannot rationalise around, and a postcondition is automatically a property test oracle.

The skill already covers fuzz, mutation, and table-driven testing. The gap was the bridge between a spec sentence ("balance never goes negative") and the tests that prove it. That bridge is the contract.

## Scoping

This is deliberately **gated by domain**, not a universal must-have:

- **Yes** — state machines, protocols, concurrency primitives, money, data migrations, authz boundaries
- **No** — CRUD glue, HTTP plumbing, config parsing (those are input validation)
- **No** — frontend/template code, scripts

The skill describes the test (would a violation indicate impossible state?) so agents don't sprinkle `assert` decoratively.

## Notes for reviewers

- Sticks to the existing reference style: concise headings, one good example per pattern, cross-links over duplication
- Uses `pgregory.net/rapid` rather than introducing new tool — already common in the Go ecosystem and well-suited to state-machine testing
- Per writing-skills TDD-for-skills, a baseline subagent test was **not** run before drafting; happy to add one as part of review if you'd like to verify the skill changes agent behaviour on a Paxos-style scenario