### PR TITLE
docs(references): add enum safety, test isolation, state-mutation rules

### DIFF
--- a/skills/go-development/references/api-design.md
+++ b/skills/go-development/references/api-design.md
@@ -425,3 +425,63 @@ if !analysis.Valid {
     log.Printf("Next run: %v, Fields: %v", analysis.NextRun, analysis.Fields)
 }
 ```
+
+## Enum & Status Type Safety
+
+Defensive handling for enum / status types so invalid values cannot be silently mishandled:
+
+- Add a `Valid()` method that returns `false` for unknown values.
+- Always include a `default` case in `switch` statements over the type.
+- Write tests for unknown/zero values, not just the known ones.
+
+```go
+type Policy int
+
+const (
+    PolicyUnknown Policy = iota // zero value — explicitly invalid, so an
+    PolicyRetry                 // uninitialized Policy is rejected by Valid()
+    PolicySkip
+    PolicyFail
+)
+
+// Valid reports whether p is a known policy. Values from deserialized data,
+// API input, or a future enum addition that isn't handled here return false.
+func (p Policy) Valid() bool {
+    switch p {
+    case PolicyRetry, PolicySkip, PolicyFail:
+        return true
+    default:
+        return false
+    }
+}
+
+func (p Policy) String() string {
+    switch p {
+    case PolicyUnknown:
+        return "unknown"
+    case PolicyRetry:
+        return "retry"
+    case PolicySkip:
+        return "skip"
+    case PolicyFail:
+        return "fail"
+    default:
+        return fmt.Sprintf("Policy(%d)", int(p)) // never panic on unknown
+    }
+}
+```
+
+Why: the zero value of an int-backed enum is always a valid `int` but may be a
+meaningless policy. A `Valid()` guard at trust boundaries (config load, API
+input, DB read) turns a silent wrong-branch bug into an explicitly rejected value.
+
+```go
+func TestPolicy_Valid_RejectsUnknown(t *testing.T) {
+    if Policy(0).Valid() { // the zero value must be rejected
+        t.Error("zero-value Policy(0) should be invalid")
+    }
+    if Policy(99).Valid() {
+        t.Error("Policy(99) should be invalid")
+    }
+}
+```

--- a/skills/go-development/references/architecture.md
+++ b/skills/go-development/references/architecture.md
@@ -117,6 +117,34 @@ func (j *LocalJob) Run(ctx context.Context) error {
 }
 ```
 
+### State Mutation Completeness
+
+When an operation changes an object's state, update **all** tracking fields in
+the same place — not just the one you came to change. Partial updates leave the
+object internally inconsistent and produce bugs that are hard to trace back to
+their cause.
+
+```go
+// After a run, update every field that describes "what happened",
+// on both the success and failure paths:
+func (j *Job) recordRun(start time.Time, err error) {
+    j.LastRunTime = start
+    j.LastDuration = time.Since(start)
+    j.RunCount++
+    j.LastError = err
+    if err != nil {
+        j.FailureCount++
+        j.Status = StatusFailed
+    } else {
+        j.Status = StatusCompleted
+    }
+}
+```
+
+Anti-pattern: bumping `RunCount` but forgetting `LastError`/`Status`, so a failed
+run still reports as "completed". Keep the mutation in one method so the full set
+is always updated together.
+
 ### Resilient Wrapper
 
 ```go

--- a/skills/go-development/references/testing.md
+++ b/skills/go-development/references/testing.md
@@ -645,6 +645,28 @@ func TestDockerIntegration(t *testing.T) {
 }
 ```
 
+### Resource Isolation: One Instance Per Test
+
+Give each test its own instance of any **stateful** fixture (scheduler, server,
+store, temp dir). Sharing a mutable instance across tests causes order-dependent
+pollution and flaky failures that often only reproduce under `-shuffle=on` or in CI.
+
+```go
+// Bad — shared, stateful scheduler: one test's jobs leak into the next
+var sharedScheduler *Scheduler // package-level
+
+// Good — each test gets a fresh instance and cleans it up
+func TestScheduler_AddJob(t *testing.T) {
+    s := NewScheduler(context.Background())
+    t.Cleanup(s.Stop)
+    // ... assert against this isolated scheduler
+}
+```
+
+Exception: a **read-only** fixture that no test mutates (see *Parallel with Shared
+Setup* below) may be shared for speed. The rule targets *mutable* state — if a
+test can change it, give each test its own.
+
 ## Coverage and Benchmarks
 
 ### Coverage


### PR DESCRIPTION
## What

Three Go coding-correctness patterns, migrated from a personal global rules file (`~/.claude/CLAUDE.md`) into the skill so the whole team gets them on demand instead of one engineer's machine.

| Reference | Added |
|---|---|
| `references/api-design.md` | **Enum & Status Type Safety** — `Valid()` returning false for unknown values, mandatory `switch` default, tests for invalid/zero values |
| `references/testing.md` | **Resource Isolation: One Instance Per Test** — fresh stateful fixture per test; harmonised with the existing read-only *Parallel with Shared Setup* exception |
| `references/architecture.md` | **State Mutation Completeness** — update all tracking fields (`LastRunTime`, `RunCount`, `LastError`, `Status`) together |

## Why

These are always-relevant Go correctness habits that had accumulated as one-off rules in a personal CLAUDE.md. Per the team principle *"skills are team memory,"* they belong in the skill. Each addition is placed next to related existing content and follows the file's Bad/Good + Why style.

## Verification

- `markdownlint-cli2` on all three files: **0 errors**.
- No behavioural/tooling changes — documentation only.