### PR TITLE
chore(release): v1.12.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-development",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Production-grade Go development patterns for resilient services",
   "repository": "https://github.com/netresearch/go-development-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires go 1.21+, golangci-lint, docker."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.11.1"
+  version: "1.12.0"
   repository: https://github.com/netresearch/go-development-skill
 allowed-tools: Bash(go:*) Bash(make:*) Bash(docker:*) Bash(golangci-lint:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Release **v1.12.0** (minor — new `feat` since v1.11.0).

Bumps `.claude-plugin/plugin.json` and `SKILL.md` metadata version 1.11.1 → 1.12.0.

Changes since v1.11.1:
- feat(references): add contracts-and-invariants
- feat: add .pre-commit-config.yaml mirroring CI checks
- docs(references): add enum safety, test isolation, state-mutation rules

After merge: signed tag `v1.12.0` on main triggers the release workflow.