### PR TITLE
docs: warn that -short pre-push smoke-test needs testing.Short() guards

### DIFF
--- a/skills/go-development/references/lefthook-template.md
+++ b/skills/go-development/references/lefthook-template.md
@@ -42,7 +42,27 @@ pre-push:
       glob: "*.go"
       run: golangci-lint run --timeout=3m
     test:
+      # -short only keeps this fast if slow/integration tests skip via
+      # `if testing.Short() { t.Skip(...) }`. Size -timeout to your slowest
+      # *unguarded* package, or the push fails on every push.
       run: go test -short -timeout=60s ./...
 ```
 
 Customize per project: add security scanning (gosec), mutation testing, etc.
+
+**Pre-push timeout pitfall.** The `-short -timeout=60s` smoke-test stays fast
+*only if* slow/integration tests honour `-short` with a
+`if testing.Short() { t.Skip(...) }` guard. A package that ignores `-short`
+(real-Docker integration tests are the classic case) runs in full, blows the
+fixed timeout, and fails the hook on **every** push — which reads like a real
+regression but is not. Diagnose before reaching for `--no-verify`:
+
+```bash
+go list -deps ./slow/pkg | grep your/changed/pkg   # import-independent of your change?
+go test -short -timeout=300s ./slow/pkg             # what does it actually take?
+```
+
+If the slow package is unrelated to your diff and pre-existing, `git push
+--no-verify` is justified — then fix the root cause separately by guarding those
+tests with `testing.Short()` (preferred, keeps the smoke-test fast) or raising
+`-timeout` to cover the slowest unguarded package.

--- a/skills/go-development/references/lefthook-template.md
+++ b/skills/go-development/references/lefthook-template.md
@@ -43,7 +43,7 @@ pre-push:
       run: golangci-lint run --timeout=3m
     test:
       # -short only keeps this fast if slow/integration tests skip via
-      # `if testing.Short() { t.Skip(...) }`. Size -timeout to your slowest
+      # testing.Short() guards. Set -timeout to cover your slowest
       # *unguarded* package, or the push fails on every push.
       run: go test -short -timeout=60s ./...
 ```
@@ -51,14 +51,14 @@ pre-push:
 Customize per project: add security scanning (gosec), mutation testing, etc.
 
 **Pre-push timeout pitfall.** The `-short -timeout=60s` smoke-test stays fast
-*only if* slow/integration tests honour `-short` with a
+*only if* slow/integration tests honor `-short` with a
 `if testing.Short() { t.Skip(...) }` guard. A package that ignores `-short`
 (real-Docker integration tests are the classic case) runs in full, blows the
 fixed timeout, and fails the hook on **every** push — which reads like a real
 regression but is not. Diagnose before reaching for `--no-verify`:
 
 ```bash
-go list -deps ./slow/pkg | grep your/changed/pkg   # import-independent of your change?
+go list -deps ./slow/pkg | grep your/changed/pkg   # if this matches, the slow package depends on your change
 go test -short -timeout=300s ./slow/pkg             # what does it actually take?
 ```
 


### PR DESCRIPTION
## Summary

The lefthook template's pre-push smoke-test is `go test -short -timeout=60s ./...`. That fixed timeout is safe **only if** slow/integration tests skip under `-short` via a `testing.Short()` guard. A package that ignores `-short` (real-Docker integration tests are the classic case) runs in full, blows the 60s timeout, and fails the push hook on **every** push — which looks like a real regression but is pre-existing infra.

## Change

`references/lefthook-template.md`:
- inline comment on the `test:` command noting the `-short` / `testing.Short()` coupling and that `-timeout` must cover the slowest *unguarded* package;
- a **Pre-push timeout pitfall** note with a diagnosis recipe (confirm the slow package is import-independent of your change; measure its true duration) and the root-cause fix (guard with `testing.Short()`, preferred, or raise `-timeout`) before reaching for `--no-verify`.

Docs-only; no behavioral change to the template's commands.
