### PR TITLE
chore(release): v1.13.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-development",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Production-grade Go development patterns for resilient services",
   "repository": "https://github.com/netresearch/go-development-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires go 1.21+, golangci-lint, docker."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.13.0"
+  version: "1.13.1"
   repository: https://github.com/netresearch/go-development-skill
 allowed-tools: Bash(go:*) Bash(make:*) Bash(docker:*) Bash(golangci-lint:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Release v1.13.1 (bump from v1.13.0): plugin.json + 1 SKILL.md version(s).