### PR TITLE
chore(release): v1.13.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-development",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Production-grade Go development patterns for resilient services",
   "repository": "https://github.com/netresearch/go-development-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires go 1.21+, golangci-lint, docker."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.13.1"
+  version: "1.13.2"
   repository: https://github.com/netresearch/go-development-skill
 allowed-tools: Bash(go:*) Bash(make:*) Bash(docker:*) Bash(golangci-lint:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Changes since v1.13.1:

- docs(skill): trim conventions, description, and reference catalog
- docs(api-design): cut generic pattern tutorials, keep enum handling
- docs(architecture): cut generic layout/job-scheduler tutorials
- docs(cron-scheduling): document ParseOption bitmask parser construction
- docs(resilience): replace with pointer to go-cron's built-in wrappers
- docs(testing): cut generic tutorial content, keep gotchas and conventions
- docs(readme): sync feature claims with trimmed references
- fix(testing): restore per-file build-tag examples as valid Go