### PR TITLE
docs(dependencies): go get -u scope, majors, and honest claim scoping

### DIFF
--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -64,6 +64,7 @@ Load as needed:
 | `references/mutation-testing.md` | Gremlins configuration, test quality measurement |
 | `references/makefile.md` | Standard Makefile interface for CI/CD |
 | `references/modernization.md` | Go 1.26 modernizers, `go fix`, `errors.AsType[T]`, `wg.Go()` |
+| `references/dependencies.md` | Upgrades: `go get -u all`, majors, build-set scoping |
 | `references/lefthook-template.md` | Ready-to-use lefthook.yml for Go project git hooks |
 | `references/reusable-workflows.md` | Reusable Actions workflow callers, permission propagation, release-gate outputs |
 | `references/single-build-release.md` | Single-build release: cross-compile once, reuse for release+container |

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: Bash(go:*) Bash(make:*) Bash(docker:*) Bash(golangci-lint:*) Read
 
 ## Required Workflow
 
-**For reviews, invoke related skills:** security-audit (OWASP), enterprise-readiness (OpenSSF/SLSA), github-project (branch protection). All are required.
+**For reviews, invoke related skills:** security-audit (OWASP), enterprise-readiness (OpenSSF/SLSA), github-project (branch protection).
 
 ## Core Principles
 
@@ -84,7 +84,7 @@ go test -race ./...                # Race detection
 
 ## Stdlib Vulnerability Fixes
 
-When `govulncheck` reports stdlib vulnerabilities: check fix version via `vuln.go.dev`, update `go X.Y.Z` in `go.mod`, run `go mod tidy`. Use PR branches for repos with branch protection.
+When `govulncheck` reports stdlib vulnerabilities: check fix version via `vuln.go.dev`, update `go X.Y.Z` in `go.mod`, run `go mod tidy`.
 
 ---
 

--- a/skills/go-development/references/dependencies.md
+++ b/skills/go-development/references/dependencies.md
@@ -36,8 +36,7 @@ a dependency is current:
 
 ```bash
 for m in $(go list -m -f '{{if not .Indirect}}{{.Path}}{{end}}' all); do
-  base=${m%/v[0-9]*}
-  cur=$(echo "$m" | grep -oE '/v[0-9]+$' | tr -d '/v'); cur=${cur:-1}
+  if [[ "$m" =~ /v([0-9]+)$ ]]; then cur="${BASH_REMATCH[1]}"; base="${m%/v*}"; else cur=1; base="$m"; fi
   go list -m "$base/v$((cur + 1))@latest" >/dev/null 2>&1 && echo "MAJOR AVAILABLE: $m -> $base/v$((cur + 1))"
 done
 ```
@@ -55,9 +54,10 @@ for code you do not ship.
 Separate "outdated" from "outdated **and in the build**" before reporting:
 
 ```bash
-go list -deps -f '{{with .Module}}{{.Path}}{{end}}' ./... | sort -u > /tmp/inbuild.txt
-go list -m -u all | grep '\[' | awk '{print $1}' | sort > /tmp/pending.txt
-comm -12 /tmp/inbuild.txt /tmp/pending.txt   # outdated AND linked in — the real list
+# outdated AND linked into the binary — the real list
+comm -12 \
+  <(go list -deps -f '{{with .Module}}{{.Path}}{{end}}' ./... | grep -v '^$' | sort -u) \
+  <(go list -m -u all | grep '\[' | awk '{print $1}' | sort)
 ```
 
 Empty output means every module you actually ship is current; the remainder is

--- a/skills/go-development/references/dependencies.md
+++ b/skills/go-development/references/dependencies.md
@@ -1,0 +1,95 @@
+# Dependency Upgrades
+
+Upgrading Go dependencies has three traps: the obvious command does less than it
+looks, majors are invisible to it, and "everything is updated" is almost never a
+claim you can make honestly.
+
+## `go get -u ./...` is not a full update
+
+`go get -u ./...` upgrades only what is needed to **build the packages matched by
+the pattern**. Modules elsewhere in the graph are untouched. `go get -u all`
+covers the whole module graph.
+
+```bash
+go get -u ./...   # build path only
+go get -u all     # whole module graph
+go mod tidy
+```
+
+**Real case:** after `go get -u ./...` reported ~26 upgrades and the tree built
+green, `go list -m -u all` still listed **44 modules with newer versions**,
+including `terraform-json` 0.27.2 → 0.28.0 and `terraform-exec` 0.25.1 → 0.25.2 —
+both in the build. Only `go get -u all` moved them. The claim "all dependencies
+upgraded" was wrong until challenged.
+
+Always confirm with the tool, not the transcript:
+
+```bash
+go list -m -u all | grep '\['   # any module with an available update prints [newer]
+```
+
+## `-u` never crosses a major version
+
+Major versions are distinct module paths (`/v2`, `/v3`), so `-u` cannot reach
+them — a v2 release is invisible to a v1 module. Check explicitly before claiming
+a dependency is current:
+
+```bash
+for m in $(go list -m -f '{{if not .Indirect}}{{.Path}}{{end}}' all); do
+  base=${m%/v[0-9]*}
+  cur=$(echo "$m" | grep -oE '/v[0-9]+$' | tr -d '/v'); cur=${cur:-1}
+  go list -m "$base/v$((cur + 1))@latest" >/dev/null 2>&1 && echo "MAJOR AVAILABLE: $m -> $base/v$((cur + 1))"
+done
+```
+
+A major bump is an import rewrite, not a version bump — scope it as its own change.
+
+## Scope the claim to what is actually in the build
+
+After `go get -u all`, `go list -m -u all` will often *still* list modules with
+newer versions. That is usually correct and not a gap: their versions are selected
+by MVS from your dependencies' own requirements, and many are test-deps-of-deps
+that never link into your binary. Forcing them means spurious `require` entries
+for code you do not ship.
+
+Separate "outdated" from "outdated **and in the build**" before reporting:
+
+```bash
+go list -deps -f '{{with .Module}}{{.Path}}{{end}}' ./... | sort -u > /tmp/inbuild.txt
+go list -m -u all | grep '\[' | awk '{print $1}' | sort > /tmp/pending.txt
+comm -12 /tmp/inbuild.txt /tmp/pending.txt   # outdated AND linked in — the real list
+```
+
+Empty output means every module you actually ship is current; the remainder is
+graph noise. That is a defensible claim. "All dependencies are latest" usually is
+not.
+
+## Verify the final tree, not an intermediate one
+
+`go get -u` raises the `go` directive when an upgraded dependency demands it
+(observed: 1.24.0 → 1.25.8). If a workflow pins Go from `.go-version`, that file
+and `go.mod` can silently disagree.
+
+```bash
+go build ./... && go vet ./...
+go mod verify
+go mod tidy && git diff --exit-code -- go.mod go.sum   # tidy drift == CI failure
+```
+
+A `depscheck`-style target runs `go mod tidy` then `git diff --exit-code` — it
+fails on **uncommitted** go.mod/go.sum, so run it after committing, or its red is
+your own working tree rather than real drift.
+
+## Dependency changes need the test job to actually run
+
+A CI `paths:` filter listing only source globs (`'**.go'`) does not match `go.mod`,
+so **every dependency PR skips the test job** — including Dependabot's. Include the
+manifest:
+
+```yaml
+paths:
+  - '**.go'
+  - 'go.mod'
+  - 'go.sum'
+  - '.go-version'
+```


### PR DESCRIPTION
The skill had **no dependency-upgrade guidance** (`grep -rin "go get -u"` returned nothing). Adds `references/dependencies.md`.

Every item below was hit in one session upgrading [netresearch/terraform-provider-ad#15](https://github.com/netresearch/terraform-provider-ad/pull/15).

## What's added

### `go get -u ./...` is not a full update

It upgrades only what the **matched packages need to build**. `go get -u all` covers the module graph.

After `./...` reported ~26 upgrades and the tree built green, `go list -m -u all` still listed **44 modules with newer versions** — including `terraform-json` 0.27.2 → 0.28.0 and `terraform-exec` 0.25.1 → 0.25.2, **both in the build**. Only `go get -u all` moved them.

The "all dependencies upgraded" claim was wrong until the maintainer challenged it with *"did you run full go mod tidy update and so on!?"*. That's the trap: the tree builds, tests pass, and the claim still isn't true.

### `-u` never crosses a major version

Majors are distinct module paths (`/v2`), so a v2 release is invisible to a v1 module. Includes an explicit probe — "no majors available" is a real finding worth stating, not an assumption.

### Scope the claim to the build set

After `go get -u all`, `go list -m -u all` **still** lists modules with updates. That's usually correct, not a gap: their versions are MVS-selected from your dependencies' own requirements, and many are test-deps-of-deps that never link in. Forcing them means spurious `require` entries for code you don't ship.

Includes the `go list -deps` intersection that separates *outdated* from *outdated **and shipped***. In the originating case that turned a vague "44 still outdated" into a defensible "all 58 modules in the build are current; the rest is graph noise."

### Two smaller traps

- `go get -u` can **raise the `go` directive** (observed 1.24.0 → 1.25.8), which can then silently disagree with a `.go-version` pin used by CI.
- A `depscheck`-style target (`go mod tidy` + `git diff --exit-code`) fails on **uncommitted** go.mod/go.sum — so its red can be your own working tree, not real drift. (Cost one false alarm.)
- A CI `paths:` filter of `'**.go'` **does not match `go.mod`**, so dependency PRs skip the test job entirely — including Dependabot's.

## SKILL.md word budget — resolved, but flagging the trims

`SKILL.md` was already at **499** words and the limit is **500**, so adding the references row required freeing words. The limit *is* CI-enforced — `Skill Validation` failed with `SKILL.md is 511 words (max 500)`. (I initially reported there was no word gate: I had grepped `validate.yml`, but the check lives in the validation **script** it calls. The gate caught me; the claim was wrong.)

Freed 11 words with two removals, both redundant rather than informative:

- **"All are required."** — the heading is `## Required Workflow` and the sentence is already imperative (*"invoke related skills"*), so this said *required* a third time.
- **"Use PR branches for repos with branch protection."** — never-push-to-main is a global rule, and line 17 already points at the `github-project` skill for branch protection.

Now exactly **500**. Both trims are one-line reverts if you'd rather free the words somewhere else — it's your file, and the constraint is real either way: at 499, *any* new reference row needs 11+ words from somewhere.

## Verification

`markdownlint-cli2` on both files: **0 errors**. Docs-only, no version bump. Every command in the reference was run in the originating session.
