### PR TITLE
docs(go-development): record three silent-failure modes from a release sweep

### DIFF
--- a/skills/go-development/references/linting.md
+++ b/skills/go-development/references/linting.md
@@ -245,6 +245,48 @@ the dual-nolint pattern for edge cases.
 
 ## Common Linter Gotchas
 
+### The Default Output Cap Silently Truncates
+
+golangci-lint stops at `max-issues-per-linter: 50` and `max-same-issues: 3` by
+default, and says nothing about what it dropped. Any count you read off a run
+is a floor, not a total.
+
+This bites hardest when taking stock before a cleanup: a report of "50 findings"
+that is really 123 turns an afternoon's work into a week's. The tell is a run
+that reports exactly 50, or two runs that list different files while reporting
+the same total.
+
+```bash
+# For an inventory, uncap it:
+golangci-lint run --max-issues-per-linter=0 --max-same-issues=0
+```
+
+Consider uncapping in the config as well. A cap also lets a regression hide
+behind it: once a linter is at its limit, the next new finding is invisible.
+
+```yaml
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  # Findings on a line another linter already reported are dropped by default.
+  uniq-by-line: false
+```
+
+### A Cache Entry Outlives Its Worktree
+
+golangci-lint can report findings with paths that no longer exist — typically
+after a git worktree is removed, when a shared cache still holds its analysis.
+The giveaway is `no such file or directory` warnings naming a deleted path
+alongside the findings.
+
+```bash
+golangci-lint cache clean
+```
+
+Treat findings whose paths you cannot open as cache artifacts, not as code
+problems, and re-run before acting on them.
+
+
 Specific linter rules that frequently trip up developers:
 
 ### dupl: Test Function Duplication

--- a/skills/go-development/references/mutation-testing.md
+++ b/skills/go-development/references/mutation-testing.md
@@ -108,6 +108,21 @@ jobs:
             echo "::warning::Mutation score below 60%"
           fi
 
+      # The `|| echo "0"` above is load-bearing in a way that hides failure:
+      # gremlins compiles the packages it mutates, and one it cannot build is
+      # reported as "[build failed]" — after which it stops without printing
+      # "Test efficacy" at all. The fallback then makes the job publish 0% and
+      # pass, which reads as a measured result rather than a run that never
+      # happened. Check for it explicitly.
+      - name: Fail on packages gremlins could not build
+        if: always()
+        run: |
+          [ -f output.txt ] || exit 0
+          grep -q '\[build failed\]' output.txt || exit 0
+          echo "::error::gremlins could not build these packages:"
+          grep '\[build failed\]' output.txt
+          exit 1
+
       - name: Upload reports
         uses: actions/upload-artifact@v4
         with:
@@ -128,6 +143,30 @@ For efficiency, only test mutations in changed files on PRs:
     BASE_REF="${{ github.event.pull_request.base.sha }}"
     gremlins unleash --config=.gremlins.yaml --diff "$BASE_REF"
 ```
+
+## A Score of 0% Means "Nothing Ran"
+
+gremlins does not partially degrade. If any package it mutates fails to
+compile, it prints `[build failed]` for that package and stops — no efficacy
+line is emitted at all. Every score-extraction idiom in the wild falls back to
+`0` when the line is missing, so the job publishes **0%** and passes.
+
+This is easy to ship and hard to notice, because a low score looks like a
+test-quality problem rather than a run that never happened.
+
+Two things cause it in practice:
+
+- **Generated sources that are not committed.** templ, sqlc, mockgen and
+  friends produce `*.go` files that CI must generate before gremlins runs.
+  A repo where `go test` works locally (generated files present) fails here.
+  Pass the codegen command in a pre-build step.
+- **Build tags.** A package that only compiles under `integration` or `e2e`
+  fails the default build.
+
+Put the `[build failed]` check in its **own step**. The run step usually
+carries `continue-on-error: true` so a low score does not fail the workflow —
+and that would swallow the build check too. A missing score is a threshold
+question; a package that does not compile is not.
 
 ## Makefile Integration
 


### PR DESCRIPTION
Three things that cost real time during a multi-repo release sweep, all of the same shape: a check that reports success while measuring nothing.

**Mutation testing — a 0% score can mean the run never happened.** The workflow example in this reference already contains `SCORE=$(grep -oP 'Test efficacy: \K[\d.]+' output.txt || echo "0")`. That fallback is doing more than it looks: gremlins compiles the packages it mutates, and one it cannot build is reported as `[build failed]` — after which it stops and prints no efficacy line at all. The job then publishes **0%** and passes. Found in [netresearch/ldap-manager](https://github.com/netresearch/ldap-manager), where uncommitted generated templ sources left three packages unbuildable; every run had reported 0% while staying green, and the handler/auth/routing package was never measured. After the fix the same repo reports 57.07%. The check is a separate step on purpose — the run step usually carries `continue-on-error: true` so a low score does not fail the workflow, and that would swallow the build check too.

**Linting — the default output cap truncates silently.** `max-issues-per-linter: 50` drops the rest without a word. A stock-take that read "about 50 findings" turned out to be 123; the tell was two runs listing different files while reporting the same total. Also notes that a cap hides regressions once a linter sits at its limit.

**Linting — a cache entry can outlive its worktree.** golangci-lint reported five findings with paths inside a git worktree that had already been removed, blocking a push via a pre-push hook. `cache clean` cleared it; the `no such file or directory` warnings alongside the findings are the giveaway.