### PR TITLE
docs(release): GoReleaser changelog filters need use:git

### DIFF
--- a/skills/go-development/references/single-build-release.md
+++ b/skills/go-development/references/single-build-release.md
@@ -305,3 +305,16 @@ Works for both tag push and workflow_dispatch "rebuild tag" backfills, so `main.
 - [reusable-workflows.md](./reusable-workflows.md) — how caller/reusable permission propagation works
 - [docker.md](./docker.md) — Docker client patterns in Go code (not Dockerfile)
 - github-project-skill [workflow-bash-patterns.md](https://github.com/netresearch/github-project-skill/blob/main/skills/github-project/references/workflow-bash-patterns.md) — bash inside `run:` gotchas
+
+## GoReleaser changelog: `use: github` ignores your filters
+
+With `changelog.use: github`, GoReleaser builds the changelog from the GitHub compare API and **silently ignores `filters.exclude`** — every `chore(deps)` / bot commit leaks into the release notes. For the exclude filters to apply, use `use: git`:
+
+```yaml
+changelog:
+  use: git
+  filters:
+    exclude:
+      - "^chore\\(deps\\)"
+      - "^ci:"
+```

--- a/skills/go-development/references/single-build-release.md
+++ b/skills/go-development/references/single-build-release.md
@@ -306,9 +306,9 @@ Works for both tag push and workflow_dispatch "rebuild tag" backfills, so `main.
 - [docker.md](./docker.md) — Docker client patterns in Go code (not Dockerfile)
 - github-project-skill [workflow-bash-patterns.md](https://github.com/netresearch/github-project-skill/blob/main/skills/github-project/references/workflow-bash-patterns.md) — bash inside `run:` gotchas
 
-## GoReleaser changelog: `use: github` ignores your filters
+## GoReleaser changelog: `github-native` ignores your filters
 
-With `changelog.use: github`, GoReleaser builds the changelog from the GitHub compare API and **silently ignores `filters.exclude`** — every `chore(deps)` / bot commit leaks into the release notes. For the exclude filters to apply, use `use: git`:
+With `changelog.use: github-native`, GoReleaser delegates to GitHub's generated-release-notes API and **ignores `sort` and `filters`** — the [upstream docs](https://goreleaser.com/customization/changelog/) mark both options "Disabled when using 'github-native'", so every `chore(deps)` / bot commit leaks into the release notes. Switch to an implementation where `filters.exclude` applies (`git`, `github`, `gitlab`, `gitea`):
 
 ```yaml
 changelog:


### PR DESCRIPTION
## What

Promoted learning (`/retro promote`, batch 6): GoReleaser with `changelog.use: github` silently ignores `filters.exclude` — all `chore(deps)` commits leak into release notes; `use: git` is required for the filters to apply. Added to `single-build-release.md`.

Came from /retro: yes
