### PR TITLE
docs: reap daemonized test helpers, and point dead guard branches the safe way

### DIFF
--- a/skills/go-development/references/contracts-and-invariants.md
+++ b/skills/go-development/references/contracts-and-invariants.md
@@ -164,10 +164,62 @@ func TestAccount_Properties(t *testing.T) {
 
 For protocols, model the state machine and let `rapid` drive transitions. The contract panics inside the implementation will surface any reachable invariant violation.
 
+## An Unreachable Branch Still Has a Direction
+
+When a guard splits on a sentinel and the remaining branch cannot be reached
+today, its behaviour is still a decision — it is the behaviour that ships the
+day the assumption stops holding. Choose it by which direction is safe then,
+not by which looks symmetric now.
+
+The trigger is a `switch` or `if`/`else` over a library's error values where
+the library currently returns only one of them:
+
+```go
+ckie, err := r.Cookie(name)
+if errors.Is(err, http.ErrNoCookie) {
+    challenge(w)                 // no cookie: nothing to clear
+    return
+}
+if err != nil {
+    clearCookie(w)               // unreachable today -- but which way should it fail?
+    challenge(w)
+    return
+}
+```
+
+`(*http.Request).Cookie` returns `ErrNoCookie` and nothing else, so the second
+branch is dead. It is also pointed the wrong way: the whole purpose of the
+first branch is *"we could not read a cookie, so do not emit a deletion"*, and
+the fallback does the opposite. If a future stdlib release ever returns another
+error there, the dead branch wakes up and re-creates the bug the guard was
+written to fix — and in this case attacker-influenced, because `readCookies`
+already degrades to `ErrNoCookie` when the cookie-count cap trips.
+
+Prefer collapsing to a single branch when every error means the same thing:
+
+```go
+ckie, err := r.Cookie(name)
+if err != nil {
+    challenge(w)                 // any lookup failure: nothing to clear
+    return
+}
+```
+
+This also removes the `errors.Is` split, which was only ever justified when the
+two branches genuinely differ. Keep the split — with a deliberate, documented
+fallback — when a future unknown error really should behave differently from
+the sentinel.
+
+Applies to any guard whose fallback is currently dead: a `default:` in a switch
+over a closed enum, an `else` after an exhaustive type assertion, a
+`case ErrNotFound` chain. Write the branch that fails safe, or delete it and
+say in the code why one branch is enough.
+
 ## Common Mistakes
 
 | Mistake | Fix |
 |---------|-----|
+| Dead fallback branch pointed the unsafe way | Fail safe, or collapse to one branch — see above |
 | Panicking on user input | Return a typed error; reserve panic for impossible states |
 | Sprinkling `assert` decoratively in glue code | Gate by domain — state machines, protocols, money, authz |
 | Postcondition that re-implements the function | Postcondition states the *property*, not the steps |

--- a/skills/go-development/references/testing.md
+++ b/skills/go-development/references/testing.md
@@ -367,6 +367,54 @@ func assertUserExists(t *testing.T, store UserStore, username string) {
 }
 ```
 
+### Reap a Daemonized Helper by Process Group
+
+A test that starts a helper server with `exec.Command` and kills it in cleanup
+looks correct and is not. `cmd.Process.Kill()` kills only the process it
+started — typically `sh -c "..."` — and the real server survives as an orphan,
+still holding the stdout it inherited from the test binary. `go test` then
+reports, *after every test has already passed*:
+
+```text
+PASS
+*** Test I/O incomplete 1m0s after exiting.
+exec: WaitDelay expired before I/O complete
+FAIL    example.com/pkg/test
+```
+
+`PASS` followed by `FAIL` is the signature. It is timing-dependent, so it
+reproduces on some runs and not others, and the orphan also holds the port —
+which makes the *next* run connect to a stale server from the previous one and
+produce a wrong diagnosis.
+
+Start the helper in its own process group and kill the group:
+
+```go
+cmd := exec.Command(shPath, "-c", command)
+cmd.Stdout = os.Stdout
+cmd.Stderr = os.Stderr
+cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+if err := cmd.Start(); err != nil {
+    t.Fatalf("can't start helper: %v", err)
+}
+
+t.Cleanup(func() {
+    // Negative PID = the whole group, so children die with the shell.
+    if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+        t.Logf("can't kill process group of %d: %v", cmd.Process.Pid, err)
+    }
+})
+```
+
+`syscall.SysProcAttr.Setpgid` is Unix-only — guard the file with
+`//go:build !windows`, or use `os/exec`'s `Cancel` plus `WaitDelay` when the
+suite must also run on Windows.
+
+Verify the fix by what it leaves behind, not by the exit code alone: after a
+green run the port must be free (`ss -ltnp | grep :<port>`). A run that passes
+while leaking the daemon has not been fixed, it has been raced.
+
 ## Related
 
 - `references/fuzz-testing.md` — fuzz testing patterns, security-focused seeds


### PR DESCRIPTION
## Summary

Two independent findings from one session, both verified against real code: reaping a daemonized test helper by process group (`testing.md`), and choosing the direction of a guard's unreachable branch (`contracts-and-invariants.md`).

## Came from

`/retro` session on 2026-08-07: `3b2909e2-2cc1-4876-a6d4-76ec690cc48d`
Finding: B16 (hard-won technique) and B18 (review-issue learning), while fixing bugs in a Go project upstream.

### 1 — `docs(testing)`: reap a daemonized helper by process group

- **Symptom:** Every test passes, then the package fails: `PASS` followed by `*** Test I/O incomplete 1m0s after exiting.` / `exec: WaitDelay expired before I/O complete` / `FAIL`. It reproduces on some runs and not others.
- **Cause:** The suite starts a helper server with `exec.Command(sh, "-c", …)` and cleans up with `cmd.Process.Kill()`, which kills only the shell. The server survives as an orphan still holding the stdout it inherited from the test binary, so `go test` waits out its I/O deadline. The orphan also keeps the port, which makes the *next* run connect to the previous run's server — that cost a wrong root-cause diagnosis before the real one was found.
- **Required behavior:** Start the helper with `SysProcAttr{Setpgid: true}` and kill the negative PID in `t.Cleanup`, so the whole group dies with the shell. Verify by the port being free after a green run, not by the exit code alone.
- **Verification:** No `evals/` in this repo. The fix shipped upstream and was confirmed: suite green (24 passed / 0 failed / 3 skipped) and port free afterwards.

### 2 — `docs(contracts)`: an unreachable branch still has a direction

- **Symptom:** A guard split on a sentinel error with a fallback branch that cannot be reached with the current library version, written for symmetry rather than for what fails safe.
- **Cause:** `(*http.Request).Cookie` returns `http.ErrNoCookie` and nothing else, so `if errors.Is(err, http.ErrNoCookie) {…}` followed by `if err != nil {…}` leaves dead code — and the dead branch did the *opposite* of the rule the guard existed to enforce. An external reviewer pointed out that if Go ever plumbed another error through, the branch would wake up and re-create the fixed bug, attacker-influenced: `readCookies` already degrades to `ErrNoCookie` when the cookie-count cap trips.
- **Required behavior:** Choose a dead branch's behaviour by what is safe the day it becomes reachable. Where every error means the same thing, collapse to one branch and say why in the code.
- **Verification:** No `evals/` in this repo. The collapsed single-branch form shipped upstream.

## Change

- `references/testing.md` — new "Reaping a Daemonized Helper by Process Group" gotcha: the `PASS`-then-`FAIL` signature, the `Setpgid` + negative-PID kill, the Windows caveat (`//go:build !windows`, or `Cancel`/`WaitDelay`), and the leak check that distinguishes a fix from a lucky race.
- `references/contracts-and-invariants.md` — new "An Unreachable Branch Still Has a Direction" section with both shapes, when keeping the split is right, and the generalisation to any dead `default`/`else`/`case`. One row added to "Common Mistakes".
- `SKILL.md` untouched — it sits exactly at the 500-word cap.

## Test plan

- [ ] `SKILL.md` still 500 words (unchanged)
- [ ] Both Go snippets compile as written; `syscall.SysProcAttr{Setpgid: true}` is guarded as Unix-only
- [ ] The `errors.Is` example matches the real `net/http` contract (`request.go`: both error returns are `ErrNoCookie`)
