### PR TITLE
feat: add branch-protection ruleset standard reference

### DIFF
--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -52,23 +52,24 @@ Load as needed:
 |-----------|---------|
 | `references/architecture.md` | Package structure, state mutation completeness |
 | `references/logging.md` | Structured logging with log/slog, migration from logrus |
-| `references/cron-scheduling.md` | go-cron patterns: named jobs, runtime updates, resilience, bitmask parser options |
+| `references/cron-scheduling.md` | go-cron patterns: named jobs, runtime updates, resilience |
 | `references/resilience.md` | Pointer to go-cron's built-in retry/circuit-breaker/timeout wrappers |
 | `references/docker.md` | Docker client patterns, buffer pooling |
 | `references/ldap.md` | LDAP/Active Directory integration |
-| `references/testing.md` | Build tags, resource isolation, race and Fiber v2 gotchas |
-| `references/linting.md` | golangci-lint v2, staticcheck, code quality |
+| `references/testing.md` | Build tags, resource isolation, race gotchas |
+| `references/linting.md` | golangci-lint v2, staticcheck |
 | `references/api-design.md` | Enum/status defensive handling |
 | `references/fuzz-testing.md` | Go fuzzing patterns, security seeds |
 | `references/contracts-and-invariants.md` | Contracts, invariants, property tests |
 | `references/mutation-testing.md` | Gremlins configuration, test quality measurement |
 | `references/makefile.md` | Standard Makefile interface for CI/CD |
-| `references/modernization.md` | Go 1.26 modernizers, `go fix`, `errors.AsType[T]`, `wg.Go()` |
+| `references/modernization.md` | Go 1.26 modernizers, `go fix`, `errors.AsType[T]` |
 | `references/dependencies.md` | Upgrades: `go get -u all`, majors, build-set scoping |
 | `references/lefthook-template.md` | Ready-to-use lefthook.yml for Go project git hooks |
+| `references/branch-protection.md` | Ruleset watermark: three-ruleset gate, bypass modes |
 | `references/reusable-workflows.md` | Reusable Actions workflow callers, permission propagation, release-gate outputs |
 | `references/single-build-release.md` | Single-build release: cross-compile once, reuse for release+container |
-| `references/awesome-go-submission.md` | awesome-go submission: CI-parsed PR body, entry format, name collisions |
+| `references/awesome-go-submission.md` | awesome-go submission: CI-parsed PR body, name collisions |
 
 ## Quality Gates
 

--- a/skills/go-development/references/branch-protection.md
+++ b/skills/go-development/references/branch-protection.md
@@ -1,0 +1,72 @@
+# Branch Protection Standard for Go Repositories
+
+The default-branch gate for Netresearch Go repos, measured as the estate
+watermark (highest standard per axis across the Go, TYPO3, and skill repos)
+and applied to all seven Go repos on 2026-08-18. Use it as the minimum for
+every new Go repo.
+
+## Use rulesets, never classic branch protection
+
+Classic protection's review settings are **invisible to the
+`repos/{r}/rules/branches/{branch}` API** — tooling that reasons from the
+rules endpoint (pr-status, preflight scripts) cannot see them, so a gate like
+`require_last_push_approval` surfaces only after everything else is green.
+Rulesets are the single queryable source of truth.
+
+## Three rulesets, not one
+
+Bypass actors attach to a **whole ruleset**. Splitting isolates the
+deliberate bypass (deps automation on the approval rule) from the rules that
+must never be bypassed (signatures, checks):
+
+| Ruleset | Rules | Bypass |
+|---|---|---|
+| `go-baseline` | `deletion`, `non_fast_forward`, `required_status_checks` (strict; the ten `go-check / *` contexts + `drift / Template drift`), `code_scanning` (CodeQL, high_or_higher/errors) | none |
+| `require-signed-commits` | `required_signatures` | none |
+| `go-pull-request` | `pull_request`: 1 approval, dismiss stale on push, thread resolution required, merge-commit only, **no** last-push approval, **no** code-owner review | Repo admins, Renovate (app 2740), Dependabot (app 29110) — all `bypass_mode: pull_request` |
+
+A separate `Copilot review for default branch` ruleset
+(`copilot_code_review`, `review_on_push: false`) usually already exists; keep
+it, do not duplicate the rule.
+
+Repos without the shared `go-check` template scale `go-baseline`'s check
+contexts to the jobs that actually run — a required context that no workflow
+emits blocks every merge forever.
+
+## Rules with a rationale
+
+- **`require_last_push_approval` stays off.** With a bot-maintainer flow
+  (agent pushes review follow-ups, then reviews), the bot is the last pusher
+  and its approval is discounted — structurally unresolvable without a second
+  human (deadlocked go-cron#399). Approver ≠ author, stale-review dismissal,
+  and thread resolution give the protection without the deadlock.
+- **CI must be in `required_status_checks`.** go-cron required only the
+  template-drift check for months: a red test suite did not block merge.
+- **`require_code_owner_reviews` only with a CODEOWNERS that resolves.**
+  GitHub ignores unresolvable owners; a CODEOWNERS pointing at a nonexistent
+  team makes the flag vacuous while reading as enforcement (go-cron#400).
+- **Bypass mode `pull_request`, never `always`.** `always` lets the actor
+  push past non-fast-forward and checks; `pull_request` only relaxes the
+  approval rule for the actor's own PRs (Renovate/Dependabot auto-merge).
+- **Merge-commit only** (`allowed_merge_methods: ["merge"]`) — atomic
+  commits, preserved signatures.
+
+## Applying to a repo
+
+```bash
+# Payload shape: {name, target: "branch", enforcement: "active",
+#   conditions: {ref_name: {include: ["~DEFAULT_BRANCH"], exclude: []}},
+#   bypass_actors: [...], rules: [...]}
+gh api repos/OWNER/REPO/rulesets -X POST --input go-baseline.json
+gh api repos/OWNER/REPO/rulesets -X POST --input require-signed-commits.json
+gh api repos/OWNER/REPO/rulesets -X POST --input go-pull-request.json
+# Read the EFFECTIVE rules back — a 2xx is not proof:
+gh api repos/OWNER/REPO/rules/branches/main --jq '[.[].type] | sort'
+# Then retire classic protection:
+gh api repos/OWNER/REPO/branches/main/protection -X DELETE
+```
+
+Copy a live ruleset as the template instead of hand-writing JSON:
+`gh api repos/netresearch/go-cron/rulesets --jq '.[]|{id,name}'`, then `GET`
+the id and adjust. Org-level rulesets would replace the per-repo copies, but
+require a paid GitHub plan (the free org tier returns 403).


### PR DESCRIPTION
Documents the default-branch protection standard for Go repos, measured as the estate watermark and applied to all seven netresearch Go repos on 2026-08-18 (go-cron, ofelia, ldap-manager, simple-ldap-go, ldap-selfservice-password-changer, raybeam, terraform-provider-ad).

New `references/branch-protection.md` covers: rulesets over classic protection (classic review settings are invisible to the `rules/branches` API), the three-ruleset split so bypass actors only relax the approval rule (never signatures or checks), why `require_last_push_approval` stays off (it deadlocks the bot-maintainer flow — netresearch/go-cron#399), required CI checks as the actual merge gate, and `pull_request`-mode bypass for Renovate/Dependabot instead of `always`.

SKILL.md gets the reference-table row; a few description cells were shortened to stay within the 500-word budget.