### PR TITLE
chore(release): v1.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "go-development",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Production-grade Go development patterns for resilient services",
-  "repository": "https://github.com/netresearch/go-development-skill",
-  "license": "(MIT AND CC-BY-SA-4.0)",
   "author": {
     "name": "Netresearch DTT GmbH",
     "url": "https://www.netresearch.de"
   },
+  "repository": "https://github.com/netresearch/go-development-skill",
+  "license": "(MIT AND CC-BY-SA-4.0)",
   "skills": [
     "./skills/go-development"
   ]

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "go-development",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Production-grade Go development patterns for resilient services",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires go 1.21+, golangci-lint, docker."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.14.0"
+  version: "1.15.0"
   repository: https://github.com/netresearch/go-development-skill
 allowed-tools: Bash(go:*) Bash(make:*) Bash(docker:*) Bash(golangci-lint:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Adds the branch-protection ruleset standard reference with CODEOWNERS routing and two rollout traps. Docs: rebind pooled LDAP connections after a user bind, with a direct leak test. Evals recover the specifics the migration dropped.