### PR TITLE
docs(dependencies): explain the go directive's runtime effect

### DIFF
--- a/skills/go-development/references/dependencies.md
+++ b/skills/go-development/references/dependencies.md
@@ -100,12 +100,12 @@ paths:
 
 ```
 go 1.26            # language version AND compatibility baseline
-toolchain go1.27.0 # which toolchain to fetch and build with
+toolchain go1.27.1 # which toolchain to fetch and build with
 ```
 
 The `toolchain` line decides what compiles. The `go` line decides what the
 result *behaves* like: Go compiles with that version's compatibility defaults
-and bakes them into the binary. So a module built by go1.27.0 while declaring
+and bakes them into the binary. So a module built by go1.27.1 while declaring
 `go 1.26` ships 1.26 semantics for everything 1.27 changed.
 
 **Only the main module's directive counts** (or the workspace's `go.work`). A
@@ -131,8 +131,9 @@ reads the *package* — neither reports the `go` directive itself, which is
 
 Those two settings are 1.27 behaviour changes, pinned back. Raise the main
 module's `go` directive to 1.27 and the `DefaultGODEBUG` line disappears
-entirely — same toolchain, same tree, only the directive differs. That two-build diff is the way to show what
-a floor actually costs, and it takes one minute.
+entirely — same toolchain, same tree, only the directive differs. That
+two-build diff is the way to show what a floor actually costs, and it takes
+one minute.
 
 One documented exception, from [go.dev/doc/godebug](https://go.dev/doc/godebug):
 *"GODEBUGs introduced for security releases will have the new behavior apply to

--- a/skills/go-development/references/dependencies.md
+++ b/skills/go-development/references/dependencies.md
@@ -104,22 +104,34 @@ toolchain go1.27.0 # which toolchain to fetch and build with
 ```
 
 The `toolchain` line decides what compiles. The `go` line decides what the
-result *behaves* like: Go compiles a module declaring an older version with
-that version's compatibility defaults and bakes them into the binary. So a
-module built by go1.27.0 while declaring `go 1.26` ships 1.26 semantics for
-everything 1.27 changed.
+result *behaves* like: Go compiles with that version's compatibility defaults
+and bakes them into the binary. So a module built by go1.27.0 while declaring
+`go 1.26` ships 1.26 semantics for everything 1.27 changed.
+
+**Only the main module's directive counts** (or the workspace's `go.work`). A
+dependency's `go` line does not reach the importing binary's defaults —
+verified by building an app at `go 1.26` against a dependency at `go 1.24`,
+then raising only the app: the dependency's version never showed up either way.
 
 Read it back rather than reasoning about it:
 
 ```bash
 go build -o /tmp/probe . && go version -m /tmp/probe | grep -E 'DefaultGODEBUG|^/'
-# /tmp/probe: go1.27.0
+# /tmp/probe: go1.27.1
 #     build   DefaultGODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0
+
+# Same answer without building, straight from the main package:
+go list -f '{{.DefaultGODEBUG}}' .
+# tracebacklabels=0,x509sslcertoverrideplatform=0
 ```
 
-Those two settings are 1.27 behaviour changes, pinned back. Raise the `go`
-directive and the `DefaultGODEBUG` line disappears — same toolchain, same
-tree, only the directive differs. That two-build diff is the way to show what
+Both were measured on go1.27.1. `go version -m` reads the *binary*, `go list`
+reads the *package* — neither reports the `go` directive itself, which is
+`go mod edit -json | jq -r '.Go'` if that is what you want.
+
+Those two settings are 1.27 behaviour changes, pinned back. Raise the main
+module's `go` directive to 1.27 and the `DefaultGODEBUG` line disappears
+entirely — same toolchain, same tree, only the directive differs. That two-build diff is the way to show what
 a floor actually costs, and it takes one minute.
 
 One documented exception, from [go.dev/doc/godebug](https://go.dev/doc/godebug):

--- a/skills/go-development/references/dependencies.md
+++ b/skills/go-development/references/dependencies.md
@@ -93,3 +93,67 @@ paths:
   - 'go.sum'
   - '.go-version'
 ```
+
+## The `go` directive is not only a floor — it selects runtime behaviour
+
+`go.mod` carries two version lines and they do different jobs:
+
+```
+go 1.26            # language version AND compatibility baseline
+toolchain go1.27.0 # which toolchain to fetch and build with
+```
+
+The `toolchain` line decides what compiles. The `go` line decides what the
+result *behaves* like: Go compiles a module declaring an older version with
+that version's compatibility defaults and bakes them into the binary. So a
+module built by go1.27.0 while declaring `go 1.26` ships 1.26 semantics for
+everything 1.27 changed.
+
+Read it back rather than reasoning about it:
+
+```bash
+go build -o /tmp/probe . && go version -m /tmp/probe | grep -E 'DefaultGODEBUG|^/'
+# /tmp/probe: go1.27.0
+#     build   DefaultGODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0
+```
+
+Those two settings are 1.27 behaviour changes, pinned back. Raise the `go`
+directive and the `DefaultGODEBUG` line disappears — same toolchain, same
+tree, only the directive differs. That two-build diff is the way to show what
+a floor actually costs, and it takes one minute.
+
+One documented exception, from [go.dev/doc/godebug](https://go.dev/doc/godebug):
+*"GODEBUGs introduced for security releases will have the new behavior apply to
+all versions."* So a low floor pins back ordinary behaviour changes, not those.
+
+### Deciding the floor
+
+The floor is a promise to whoever compiles the module, so ask who that is
+before keeping it low:
+
+- **Library** — importers inherit it through MVS. Keep the floor low
+  deliberately; raising it forces every consumer up. Check who they are:
+  `https://pkg.go.dev/<module>?tab=importedby` says *"No known importers for
+  this package!"* when there are none.
+- **Application** — users consume binaries and images, not the module. If the
+  Dockerfile packages a prebuilt binary rather than compiling, and CI resolves
+  its toolchain from `go.mod` (`setup-go` with `go-version-file`), then the
+  floor buys nothing and costs the pinned-back behaviour above.
+
+A repository that inherited its floor from a sibling library without
+inheriting the reason is the common case worth checking.
+
+### Raising it
+
+`go.mod` is not the only surface. Sweep **without an extension filter** — the
+files that *enforce* the version are often dotfiles a `--include='*.md'` pattern
+cannot match:
+
+```bash
+grep -rn '1\.26' . --exclude-dir=.git --exclude=CHANGELOG.md
+# go.mod, docs/DEVELOPMENT.md, CONTRIBUTING.md … and .envrc's REQUIRED_VERSION
+```
+
+The README's `img.shields.io/github/go-mod/go-version` badge reads the `go`
+directive, so it follows on its own — and reports the floor, not the toolchain,
+which is why a repo building with 1.27 can advertise 1.26 and look wrong.


### PR DESCRIPTION
A `/retro` finding from releasing [netresearch/ofelia v1.0.0](https://github.com/netresearch/ofelia/releases/tag/v1.0.0). The repository's README badge advertised Go 1.26 while CI built with 1.27, which read as a broken badge. It was correct: the badge reads the `go` directive, and the directive was 1.26.

Working out why that mattered took a measurement neither this skill nor the Go docs put in one place, so the next person starts from zero.

## What the section adds

The `go` directive is routinely read as a build floor. It is also what selects the compatibility defaults compiled into the binary, so a module built by go1.27.0 while declaring `go 1.26` ships 1.26 semantics for everything 1.27 changed.

Measured on ofelia rather than argued:

```
go 1.26  + toolchain go1.27.0 -> DefaultGODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0
go 1.27  + toolchain go1.27.0 -> (absent)
```

Same toolchain, same tree, only the directive differs. `go version -m` reads it back off the binary and `go list -f '{{.DefaultGODEBUG}}'` off the package without building, which turns "does the floor cost anything" from an argument into a one-minute diff.

Only the **main module's** directive does this. Review raised the scoping question, so it was measured rather than argued: an app at `go 1.26` built against a dependency at `go 1.24`, then the app alone raised to `1.27`. The dependency's version never appeared in either binary, and the `DefaultGODEBUG` line vanished when the app moved. The section says so now.

The section also carries the question that decides whether to keep a floor — library (importers inherit it through MVS; check `?tab=importedby`) versus application (users consume binaries, so the floor buys nothing) — and the sweep needed when raising it. That sweep has to run **without** an extension filter: on ofelia the enforcing surface was `.envrc`'s `REQUIRED_VERSION`, which no `--include='*.md'` pattern can match.

## Checked, not recalled

- The security exemption is quoted verbatim from [go.dev/doc/godebug](https://go.dev/doc/godebug) — my first draft generalized it to "an old floor never withholds security fixes", which the source does not say.
- The pkg.go.dev string *"No known importers for this package!"* was fetched, not remembered.
- CodeRabbit's claim that `go version -m` cannot show the compiled defaults was checked and **not** taken: on go1.27.1 it prints `build DefaultGODEBUG=…`, which is what the example shows. `go list` returns the identical string, so it went in as an addition. Its scoping finding was taken in full.

`markdownlint-cli2` and the rest of the pre-commit set pass; the commit is signed.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01FaJYTTjfqhBJisARa6g5BE)_
