### PR TITLE
chore(release): v1.15.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-development",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Production-grade Go development patterns for resilient services",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "go-development",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Production-grade Go development patterns for resilient services",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires go 1.21+, golangci-lint, docker."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.15.1"
+  version: "1.15.2"
   repository: https://github.com/netresearch/go-development-skill
 allowed-tools: Bash(go:*) Bash(make:*) Bash(docker:*) Bash(golangci-lint:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Version bump to 1.15.2 (patch). Changes since v1.15.1:

- docs: complete the marketplace setup steps
- docs: correct the skills-directory install instructions
- chore(dependabot): remove the Dependabot configuration

Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
Assisted-by: claude-code:claude-opus-5
Agent-Session: https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5