### PR TITLE
docs: Go 1.27 upgrade evidence, dependency replacement, and hand-rolled mutations

### DIFF
--- a/skills/go-development/references/dependencies.md
+++ b/skills/go-development/references/dependencies.md
@@ -94,6 +94,76 @@ paths:
   - '.go-version'
 ```
 
+## Replacing an archived dependency: prove the swap, do not assume it
+
+An archived module is a reason to move, but the replacement is a behaviour change
+until measured. Two things to establish before the commit message claims a
+drop-in.
+
+**Enumerate every symbol and every struct tag you use**, not just the one call
+you remember. A fork can keep a signature and change how it reads a tag. The
+cheap evidence is a differential probe: a throwaway module importing both
+libraries, feeding the same inputs through each, comparing results *and*
+whether an error was returned. Copy the real structs with their real tags —
+reconstructed fixtures test the reconstruction. Control-test the probe by
+injecting one difference and checking it reports it; a probe that cannot fail
+is not evidence.
+
+**Read the advisory rather than a summary.** The advisory in this area may be
+against the module you are migrating *to*: `go-viper/mapstructure/v2` carries
+CVE-2025-11065 for `<= 2.3.0`, while the archived `mitchellh/mapstructure` has
+no advisory at all. Take the package, the range and the first patched version
+from `gh api /advisories?cve_id=<CVE>` or the OSV record.
+
+Error *text* is part of the contract when it reaches a user. The same
+mapstructure change stops quoting the offending value back in a decode error, so
+any message a provider or CLI surfaces changes wording without changing
+behaviour. Grep for tests asserting on it, and put it in the release notes.
+
+## Moving to a standard-library replacement: check the acceptance set
+
+Go 1.27 ships `uuid`, which makes `github.com/hashicorp/go-uuid` and friends
+removable. The generation side is a clean swap; the parsing side is not.
+
+`hashicorp/go-uuid`'s `ParseUUID` accepts exactly the canonical 36-character
+hyphenated form. `uuid.Parse` also accepts the URN form
+(`urn:uuid:...`), the unhyphenated 32-character form, and the brace-wrapped
+form. Swapping it into a validator therefore *widens* what that validator
+accepts, silently — and for a value that is echoed back canonicalised by the
+system it addresses, a widened validator trades an error at validation time for
+a diff that never settles.
+
+Keep the old acceptance set explicitly:
+
+```go
+func parseGUID(s string) error {
+	if len(s) != 36 {
+		return fmt.Errorf("uuid string is wrong length")
+	}
+	_, err := uuid.Parse(s)
+	return err
+}
+```
+
+The length check is what makes it strict; the three wider spellings are 45, 32
+and 38 bytes. Pin it with a table test that lists those three as rejected, and
+confirm the test fails when the length check is removed — otherwise the guard is
+asserting nothing.
+
+Two more things the swap changes:
+
+- **Rejection wording.** `go-uuid` returned `uuid is improperly formatted`; the
+  standard library returns `invalid uuid`. Anywhere that interpolates the parse
+  error into a user-facing message now reads differently.
+- **The generated value's shape.** `go-uuid`'s `GenerateUUID` formatted sixteen
+  random bytes *without* setting the version and variant bits, so it never
+  produced a valid v4. `uuid.New()` does. If the value is stored, say so.
+
+`uuid.UUID` is a `[16]byte`, so a `%s` verb renders raw bytes unless `String` is
+reached. That form compiles and `go vet` accepts it, so assert the rendering
+somewhere — and assert it by calling the production code, not by rebuilding the
+expression in the test.
+
 ## The `go` directive is not only a floor — it selects runtime behaviour
 
 `go.mod` carries two version lines and they do different jobs:

--- a/skills/go-development/references/dependencies.md
+++ b/skills/go-development/references/dependencies.md
@@ -120,6 +120,10 @@ mapstructure change stops quoting the offending value back in a decode error, so
 any message a provider or CLI surfaces changes wording without changing
 behaviour. Grep for tests asserting on it, and put it in the release notes.
 
+"No advisory" is not "unaffected". The archived module leaks the same value into
+the same message; it has no advisory because nobody is filing them for it. Read
+an absent advisory as an absent maintainer.
+
 ## Moving to a standard-library replacement: check the acceptance set
 
 Go 1.27 ships `uuid`, which makes `github.com/hashicorp/go-uuid` and friends
@@ -152,17 +156,27 @@ asserting nothing.
 
 Two more things the swap changes:
 
-- **Rejection wording.** `go-uuid` returned `uuid is improperly formatted`; the
-  standard library returns `invalid uuid`. Anywhere that interpolates the parse
-  error into a user-facing message now reads differently.
+- **Rejection wording.** `go-uuid` returned one of four messages depending on
+  which check failed — `uuid string is wrong length`, `uuid is improperly
+  formatted` for a misplaced separator, a raw `encoding/hex` error, or `decoded
+  hex is the wrong length`. The standard library returns `invalid uuid` for all
+  of them. Anywhere that interpolates the parse error into a user-facing message
+  now reads differently, and a test matching on one of the four stops matching.
 - **The generated value's shape.** `go-uuid`'s `GenerateUUID` formatted sixteen
-  random bytes *without* setting the version and variant bits, so it never
-  produced a valid v4. `uuid.New()` does. If the value is stored, say so.
+  random bytes *without* setting the version and variant bits, so it did not
+  produce a v4 by construction — about one output in 64 was a valid v4 by
+  chance, which is why "never" is the wrong word and a sampling check is the
+  wrong test. `uuid.New()` sets both. If the value is stored, say so.
 
-`uuid.UUID` is a `[16]byte`, so a `%s` verb renders raw bytes unless `String` is
-reached. That form compiles and `go vet` accepts it, so assert the rendering
-somewhere — and assert it by calling the production code, not by rebuilding the
-expression in the test.
+One thing that is *not* a hazard here, because it is easy to assume it is:
+`uuid.UUID` is a `[16]byte`, but `String` has a **value** receiver, so a `%s`
+verb reaches it for both a value and a pointer. There is no plain `%s` spelling
+that prints raw bytes. Getting them requires deliberately leaving the type —
+`u[:]`, `[16]byte(u)`, `%x` — which is not something a refactor does by accident.
+
+Assert the rendering only where production code adds formatting of its own, such
+as composing the value into a larger identifier. Assert it by calling that code,
+never by rebuilding its expression in the test.
 
 ## The `go` directive is not only a floor — it selects runtime behaviour
 

--- a/skills/go-development/references/modernization.md
+++ b/skills/go-development/references/modernization.md
@@ -33,6 +33,57 @@ go fix -fix=any ./...
 | `reflecttypefor` | `reflect.TypeOf((*T)(nil)).Elem()` → `reflect.TypeFor[T]()` | Cleaner generic form |
 | `stringsbuilder` | `output += s` → `strings.Builder` | Better performance for string concatenation |
 
+### Proving a construct needs the new language version
+
+`go fix` only applies modernizers your `go.mod` allows, so after a directive
+raise some rewrites are not style choices — they are constructs the previous
+language version rejected. Do not assert that from the release notes. Build the
+same file under both directives and let the compiler say so:
+
+```bash
+mkdir -p /tmp/langprobe && cd /tmp/langprobe
+cat > p.go <<'EOF'
+package p
+
+type Inner struct{ A string }
+type Outer struct {
+	Inner
+	B string
+}
+
+var _ = Outer{A: "x", B: "y"}
+EOF
+for v in 1.26.0 1.27.0; do
+  printf 'module langprobe
+
+go %s
+' "$v" > go.mod
+  printf "go %s: " "$v"; go build ./... 2>&1 | tail -1 || echo compiles
+done
+```
+
+```
+go 1.26.0: ./p.go:9:15: use of promoted field Inner.A in struct literal of type
+           Outer requires go1.27 or later (-lang was set to go1.26; check go.mod)
+go 1.27.0: compiles
+```
+
+The diagnostic names the version, which turns "this is a 1.27 feature" from a
+claim into evidence — worth putting in the pull request, because a review bot
+whose model predates the toolchain will report exactly these lines as a compile
+error and propose undoing them.
+
+**Go 1.27: promoted fields in composite literals.** `Outer{A: "x"}` for a field
+promoted from an embedded struct is the rewrite most visible after raising the
+directive to 1.27, and `go fix` produces it. An embedded field whose promoted
+name equals its own type name cannot be flattened — `Unicode: Unicode{Unicode:
+"yes"}` stays wrapped, because `Unicode:` in that literal is the embedded field,
+not the promoted string. A mixed result is correct, not an inconsistency.
+
+Confirm a flattened literal still builds the same value before trusting it: a
+`reflect.DeepEqual` comparison against the wrapped form costs one throwaway test
+and rules out the promoted name resolving to a different field.
+
 ### go fix Best Practices
 
 1. **Run after upgrading Go** — `go fix` detects your `go.mod` version and only applies applicable modernizers

--- a/skills/go-development/references/modernization.md
+++ b/skills/go-development/references/modernization.md
@@ -54,17 +54,21 @@ type Outer struct {
 var _ = Outer{A: "x", B: "y"}
 EOF
 for v in 1.26.0 1.27.0; do
-  printf 'module langprobe
-
-go %s
-' "$v" > go.mod
-  printf "go %s: " "$v"; go build ./... 2>&1 | tail -1 || echo compiles
+  { echo "module langprobe"; echo; echo "go $v"; } > go.mod
+  out=$(go build ./... 2>&1); rc=$?
+  if [ $rc -eq 0 ]; then printf 'go %s: compiles\n' "$v"
+  else printf 'go %s: %s\n' "$v" "$out"; fi
 done
 ```
 
+Capture the status; do not pipe it. `go build ./... | tail -1` reports `tail`'s
+exit status, so a failed build looks like a success and the branch printing the
+success marker never runs — which is how a plausible transcript ends up in a
+document without ever having been produced by the script above it.
+
 ```
-go 1.26.0: ./p.go:9:15: use of promoted field Inner.A in struct literal of type
-           Outer requires go1.27 or later (-lang was set to go1.26; check go.mod)
+go 1.26.0: # langprobe
+./p.go:9:15: use of promoted field Inner.A in struct literal of type Outer requires go1.27 or later (-lang was set to go1.26; check go.mod)
 go 1.27.0: compiles
 ```
 
@@ -75,7 +79,9 @@ error and propose undoing them.
 
 **Go 1.27: promoted fields in composite literals.** `Outer{A: "x"}` for a field
 promoted from an embedded struct is the rewrite most visible after raising the
-directive to 1.27, and `go fix` produces it. An embedded field whose promoted
+directive to 1.27. The modernizer is `embedlit`; on the same tree with `go
+1.26.0` in `go.mod` it produces no diff at all, which is the gating in action.
+An embedded field whose promoted
 name equals its own type name cannot be flattened — `Unicode: Unicode{Unicode:
 "yes"}` stays wrapped, because `Unicode:` in that literal is the embedded field,
 not the promoted string. A mixed result is correct, not an inconsistency.

--- a/skills/go-development/references/mutation-testing.md
+++ b/skills/go-development/references/mutation-testing.md
@@ -239,16 +239,38 @@ Two rules follow:
 ```bash
 cp pkg/thing.go /tmp/thing.bak
 # ... inject, then:
-go build ./... >/dev/null 2>&1 || { echo "BUILD BROKEN — not evidence"; }
-go test ./... ; echo "exit=$?"
+if ! out=$(go vet ./... 2>&1); then
+  echo "DOES NOT BUILD — not evidence:"; echo "$out"
+else
+  go test ./...; echo "exit=$?"
+fi
 cp /tmp/thing.bak pkg/thing.go
 ```
+
+The guard has to come first and it has to stop. `go build ... || echo warning`
+prints the warning and then runs the suite anyway, so the compile failure still
+reaches the exit code the loop reads — the sample would demonstrate the defect it
+exists to prevent. Keep the diagnostic rather than discarding it to
+`/dev/null`: "which mutation failed to build" is the thing you need next.
+
+`go vet` is the gate rather than `go build`, because `go test` runs vet too. A
+mutation that builds and only trips vet — a `%d` verb given a string, say —
+passes a `go build` guard and then produces the identical
+`FAIL [build failed]` the section is about.
 
 A mutation that survives is the finding. Before writing the test that catches it,
 check the assertion will reach the mutated code at all: a test that rebuilds the
 production expression in its own body holds whatever production does, so it stays
 green through every mutation of the real thing. Extract the expression into a
-named function and call it from both sides.
+named function and have production call it.
+
+Then have the test call it for the **actual** value only. The expected value must
+come from somewhere the mutation cannot move: a literal, or an invariant of the
+result. Calling the extracted function on both sides reproduces the original
+defect one level up — a mutation shifts both sides together and the test stays
+green. "The id splits into two parts on the underscore, the first is this literal
+GUID, the second parses as a GUID, and two calls differ" are invariants; "equals
+`membershipID(group)`" is not an assertion at all.
 
 ## Best Practices
 

--- a/skills/go-development/references/mutation-testing.md
+++ b/skills/go-development/references/mutation-testing.md
@@ -214,6 +214,42 @@ func TestIsValid(t *testing.T) {
 }
 ```
 
+## Hand-rolled mutations: a build failure is not a caught defect
+
+Gremlins is the tool, but a targeted question — "does anything actually pin this
+one line?" — is usually answered faster by injecting the defect yourself. That
+loop has a failure mode the tool does not have, and it reports the wrong answer
+in the reassuring direction.
+
+Removing a call often orphans its import. `go test ./...` then exits non-zero on
+`"slices" imported and not used`, the loop sees a non-zero exit, and prints
+CAUGHT for a mutation no assertion ever saw. The run measured the compiler.
+
+Two rules follow:
+
+- **Every mutation must build clean before its result counts.** Check for a
+  compiler diagnostic (`# package` lines, `[build failed]`), not just the exit
+  code. Where a mutation would orphan a symbol, keep it referenced —
+  `_ = slices.Clone(x)`, `_ = uuid.New()` — so the defect is the only change.
+- **Restore from a copy, never `git checkout -- <file>`.** That restores the last
+  *committed* state, discarding the guard you just wrote and have not committed.
+  `cp file /tmp/x.bak` first, `cp` back after each mutation, and run the full
+  suite at the end to prove the tree is the one you think it is.
+
+```bash
+cp pkg/thing.go /tmp/thing.bak
+# ... inject, then:
+go build ./... >/dev/null 2>&1 || { echo "BUILD BROKEN — not evidence"; }
+go test ./... ; echo "exit=$?"
+cp /tmp/thing.bak pkg/thing.go
+```
+
+A mutation that survives is the finding. Before writing the test that catches it,
+check the assertion will reach the mutated code at all: a test that rebuilds the
+production expression in its own body holds whatever production does, so it stays
+green through every mutation of the real thing. Extract the expression into a
+named function and call it from both sides.
+
 ## Best Practices
 
 1. **Start with 60% threshold** - Increase as tests mature


### PR DESCRIPTION
Merging this adds three sections to the Go references, covering ground a Go 1.27 upgrade and a dependency replacement hit that the skill did not answer. Documentation only; no scripts or templates change.

Each section comes from a measured failure or a non-obvious result, not from a reading of the release notes.

## `references/modernization.md` — proving a construct needs the new language version

The file already says to run `go fix -diff` first and that unused imports may be left behind. What it did not say is how to establish that a rewrite is *version-gated* rather than cosmetic — which is the half a reviewer questions. Building the same file under two `go` directives makes the compiler name the version itself (`requires go1.27 or later (-lang was set to go1.26)`), which turns the claim into evidence.

Go 1.27's promoted fields in composite literals are the worked example, including the case that **cannot** be flattened: an embedded field whose promoted name equals its own type name. A mixed result there is correct rather than an oversight, and saying so keeps the next reader from "tidying" it. The section also says to confirm a flattened literal still builds the same value — a promoted name resolving to a different field compiles and passes anything that does not look at the value.

## `references/dependencies.md` — replacing an archived module, and the stdlib `uuid` trap

Two new sections. The first is about evidence: a fork can keep a signature and change how it reads a struct tag, so "drop-in" needs a differential probe over the real structs with their real tags, control-tested by injecting a difference. It warns that the advisory in this area may be against the module being migrated **to** — CVE-2025-11065 is against `go-viper/mapstructure/v2 <= 2.3.0`, while the archived `mitchellh/mapstructure` has none — and that a decode error's text is part of the contract once a user reads it.

The second is a trap with a quiet failure mode. Go 1.27 ships `uuid`, and `uuid.Parse` accepts three spellings `hashicorp/go-uuid` rejects (URN, unhyphenated 32, brace-wrapped). Dropping it into a validator therefore widens what that validator accepts. For an identifier the addressed system echoes back canonicalised, that trades an error at validation time for a diff that never settles. The length check restoring the old acceptance set is given, with the instruction to confirm the test fails without it. Rejection wording and the generated value's shape both change too, and the `%s`-on-a-`[16]byte` form compiles and `go vet` accepts it.

## `references/mutation-testing.md` — a hand-injected mutation that fails to build proves nothing

The file covers gremlins reporting `[build failed]` per package. It did not cover the loop a targeted check actually uses — inject by hand, run the suite, read the exit code — which fails in the reassuring direction: removing a call orphans its import, the suite exits non-zero on a compiler error, and the loop prints CAUGHT for a mutation no assertion saw. Keep the symbol referenced so the defect is the only change, and look for a diagnostic before believing an exit code.

Restoring from `git checkout --` is the second half: it restores the last *committed* state and silently takes the uncommitted guard with it, leaving a green suite because both the test and its subject are gone.

It closes with why a surviving mutation sometimes cannot be fixed by adding an assertion: a test that rebuilds the production expression in its own body tracks whatever production does, and stays green through every mutation of it.

## Review round

A fact-check of every checkable assertion refuted one and found two shell samples that cannot produce the output printed beneath them. Fixed in `c8711fa`.

**The `%s` claim was wrong, not imprecise.** `uuid.UUID` is a `[16]byte`, but `String` has a **value** receiver, so `%s` reaches it for a value and a pointer alike — there is no plain spelling that prints raw bytes. Getting them takes a deliberate `u[:]`, `[16]byte(u)` or `%x`. That paragraph now exists to say this is *not* a hazard, because it is easy to assume it is, and the surviving advice is narrower: assert formatting only where production adds formatting of its own.

**The version probe could not have printed its own output.** `go build ./... | tail -1` reports `tail`'s status, so `|| echo compiles` never fires and the success line had been written by hand. The loop captures the status now and the block below it is that run's actual output; the doc says why, since the trap is general. A `printf` whose escapes were expanded when the file was written is repaired at the same time.

**The mutation sample demonstrated the defect the section prevents.** `go build ... || { echo "BUILD BROKEN"; }` prints and falls through, so `go test` ran anyway and the compile failure still reached the exit code. It is an if/else now, keeps the diagnostic, and gates on `go vet` rather than `go build` — because `go test` runs vet too, so a mutation that only trips vet passes a build guard and produces the identical `FAIL [build failed]`. Both shapes were run against the corrected sample.

**Extract-and-call was half a rule.** Calling the extracted function on both sides of an assertion reproduces the original defect one level up: the mutation moves both values and the test stays green. Production calls it; the test calls it for the actual value only, and the expected value must be a literal or an invariant.

Three overclaims narrowed to what the source supports: `ParseUUID` returns one of four messages rather than one; `GenerateUUID` did not produce a v4 *by construction*, but roughly one output in 64 was a valid v4 by chance, so "never" invites a sampling check that proves nothing; and "the archived module has no advisory" reads as safer than it is — it leaks the same value into the same message and simply has nobody filing advisories. The `embedlit` modernizer is named, since the table above the section does not list it.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01NTk1ART7kB8M4ZZRJjcAzn)_

https://claude.ai/code/session_01NTk1ART7kB8M4ZZRJjcAzn
