### PR TITLE
chore(release): v1.15.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-development",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Production-grade Go development patterns for resilient services",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "go-development",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "Production-grade Go development patterns for resilient services",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/go-development/SKILL.md
+++ b/skills/go-development/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires go 1.21+, golangci-lint, docker."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.15.2"
+  version: "1.15.3"
   repository: https://github.com/netresearch/go-development-skill
 allowed-tools: Bash(go:*) Bash(make:*) Bash(docker:*) Bash(golangci-lint:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Three new reference sections from a Go 1.27 upgrade, and a correction round over them.

`modernization.md` gains how to prove a construct is version-gated rather than cosmetic: build the same file under two `go` directives and let the compiler name the version. Go 1.27's promoted fields in composite literals are the worked example, including the embedded field whose promoted name equals its own type name and therefore cannot be flattened.

`dependencies.md` gains two sections — migrating off an archived module, where a fork can keep a signature and change how it reads a struct tag, and the standard-library `uuid` trap, where `uuid.Parse` accepts three spellings `hashicorp/go-uuid` rejects and a naive swap silently widens any validator built on it.

`mutation-testing.md` gains the hand-rolled loop: a mutation that orphans an import makes `go test` exit non-zero on a build error, which an exit-code-only check reads as a caught defect. The guard gates on `go vet`, because `go test` runs vet too.

A review of those sections refuted one claim outright — `%s` on a `uuid.UUID` reaches `String`, it does not render raw bytes — and found two shell samples that could not have produced the output printed beneath them. Both are corrected and the transcripts are now real. Three further claims are narrowed to what the source supports.